### PR TITLE
use importcpp for struct and classes in --header --cpp mode

### DIFF
--- a/cparse.nim
+++ b/cparse.nim
@@ -662,8 +662,9 @@ proc structPragmas(p: TParser, name: PNode, origName: string): PNode =
   var pragmas = newNodeP(nkPragma, p)
   #addSon(pragmas, newIdentNodeP("pure", p), newIdentNodeP("final", p))
   if p.options.useHeader:
+    let importStr = if pfCpp in p.options.flags: "importcpp" else: "importc" 
     addSon(pragmas,
-      newIdentStrLitPair("importc", p.currentNamespace & origName, p),
+      newIdentStrLitPair(importStr, p.currentNamespace & origName, p),
       newIdentStrLitPair("header", p.getHeader, p))
   if pragmas.len > 0: addSon(result, pragmas)
   else: addSon(result, ast.emptyNode)


### PR DESCRIPTION
importcpp was needed to make templated classes and structs work out of the box for the generated nim code when using --cpp and --header.

No tests have been broken since the combination of --cpp and --header is not being currently tested.