### PR TITLE
require less recent compiler (fixes #38)

### DIFF
--- a/c2nim.nimble
+++ b/c2nim.nimble
@@ -8,5 +8,4 @@ license       = "MIT"
 bin = "c2nim"
 
 [Deps]
-Requires: "nim >= 0.10.3, compiler#devel"
-
+Requires: "nim >= 0.10.3, compiler >= 0.10.3"


### PR DESCRIPTION
`compiler#devel` doesn't work when not using latest devel Nim. 