### PR TITLE
Add support for bitfields

### DIFF
--- a/cparse.nim
+++ b/cparse.nim
@@ -774,8 +774,6 @@ proc parseStructBody(p: var Parser, stmtList: PNode, isUnion: bool,
       var t = pointer(p, baseTyp)
       var i = parseField(p, kind)
       t = parseTypeSuffix(p, t)
-      addSon(def, i, t, ast.emptyNode)
-      addSon(result, def)
       if p.tok.xkind == pxColon:
         getTok(p)
         var bits = p.tok.iNumber
@@ -785,7 +783,12 @@ proc parseStructBody(p: var Parser, stmtList: PNode, isUnion: bool,
         addSon(bitsize, newIdentNodeP("bitsize", p))
         addSon(bitsize, newIntNodeP(nkIntLit, bits, p))
         addSon(pragma, bitsize)
-        addSon(result, pragma)
+        var pragmaExpr = newNodeP(nkPragmaExpr, p)
+        addSon(pragmaExpr, i)
+        addSon(pragmaExpr, pragma)
+        i = pragmaExpr
+      addSon(def, i, t, ast.emptyNode)
+      addSon(result, def)
       if p.tok.xkind != pxComma: break
       getTok(p, def)
     eat(p, pxSemicolon, lastSon(result))
@@ -2554,4 +2557,3 @@ proc parseUnit(p: var Parser): PNode =
   except ERetryParsing:
     parMessage(p, errGenerated, getCurrentExceptionMsg())
     #"Uncaught parsing exception raised")
-

--- a/cparse.nim
+++ b/cparse.nim
@@ -776,6 +776,13 @@ proc parseStructBody(p: var Parser, stmtList: PNode, isUnion: bool,
       t = parseTypeSuffix(p, t)
       addSon(def, i, t, ast.emptyNode)
       addSon(result, def)
+      if p.tok.xkind == pxColon:
+        getTok(p)
+        var bits = p.tok.iNumber
+        eat(p, pxIntLit)
+        var pragma = newNodeP(nkPragma, p)
+        addSon(pragma, newIdentNodeP("bitsize:" & $bits, p))
+        addSon(result, pragma)
       if p.tok.xkind != pxComma: break
       getTok(p, def)
     eat(p, pxSemicolon, lastSon(result))

--- a/cparse.nim
+++ b/cparse.nim
@@ -781,7 +781,10 @@ proc parseStructBody(p: var Parser, stmtList: PNode, isUnion: bool,
         var bits = p.tok.iNumber
         eat(p, pxIntLit)
         var pragma = newNodeP(nkPragma, p)
-        addSon(pragma, newIdentNodeP("bitsize:" & $bits, p))
+        var bitsize = newNodeP(nkExprColonExpr, p)
+        addSon(bitsize, newIdentNodeP("bitsize", p))
+        addSon(bitsize, newIntNodeP(nkIntLit, bits, p))
+        addSon(pragma, bitsize)
         addSon(result, pragma)
       if p.tok.xkind != pxComma: break
       getTok(p, def)

--- a/testsuite/results/bitfield.nim
+++ b/testsuite/results/bitfield.nim
@@ -1,7 +1,5 @@
 type
   bits* = object
-    flag*: cint
-    {.bitsize:1.}
-    opts*: cint
-    {.bitsize:4.}
+    flag* {.bitsize: 1.}: cint
+    opts* {.bitsize: 4.}: cint
 

--- a/testsuite/results/bitfield.nim
+++ b/testsuite/results/bitfield.nim
@@ -1,0 +1,7 @@
+type
+  bits* = object
+    flag*: cint
+    {.bitsize:1.}
+    opts*: cint
+    {.bitsize:4.}
+

--- a/testsuite/tests/bitfield.h
+++ b/testsuite/tests/bitfield.h
@@ -1,0 +1,4 @@
+struct bits {
+  int flag:1;
+  int opts:4;
+};


### PR DESCRIPTION
will close https://github.com/nim-lang/c2nim/issues/49

I'm emitting a `bitsize` pragma as @Varriount suggested, but it's currently showing up after the type instead of as part of it.

``` nim
type
  bits* = object
    flag*: cint
    {.bitsize:1.}
    opts*: cint
    {.bitsize:4.}
```