### PR TITLE
Empty #define and reserve word defines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os: linux
 install:
   - git clone https://github.com/nim-lang/nim
   - cd nim
-  - ./bootstrap.sh
+  - sh ./bootstrap.sh
   - export PATH=$(pwd)/bin:$PATH
   - nim e install_nimble.nims
   - nimble install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 language: c
 os: linux
 install:

--- a/c2nim.nim
+++ b/c2nim.nim
@@ -13,10 +13,11 @@ import
   clex, cparse, postprocessor
 
 const
-  Version = "0.9.8" # keep in sync with Nimble version. D'oh!
+  Version = "0.9.9" # keep in sync with Nimble version. D'oh!
   Usage = """
 c2nim - C to Nim source converter
-  (c) 2015 Andreas Rumpf
+  Version """ & $Version & " [" & $hostOS & ": " & $hostCPU & """]
+  Copyright (c) 2015 Andreas Rumpf
 Usage: c2nim [options] [optionfile(s)] inputfile(s) [options]
   Optionfiles are C files with the 'c2nim' extension. These are parsed like
   other C files but produce no output file.

--- a/c2nim.nim
+++ b/c2nim.nim
@@ -54,7 +54,7 @@ proc parse(infile: string, options: PParserOptions): PNode =
   result = parseUnit(p).postprocess
   closeParser(p)
 
-proc isC2nimFile(s: string): bool = splitFile(s).ext.toLower == ".c2nim"
+proc isC2nimFile(s: string): bool = splitFile(s).ext.toLowerAscii == ".c2nim"
 
 proc main(infiles: seq[string], outfile: var string,
           options: PParserOptions, concat: bool) =
@@ -103,7 +103,7 @@ for kind, key, val in getopt():
            " use a list of files and --concat instead"
     else:
       if not parserOptions.setOption(key, val):
-        stdout.writeln("[Error] unknown option: " & key)
+        stdout.writeline("[Error] unknown option: " & key)
   of cmdEnd: assert(false)
 if infiles.len == 0:
   # no filename has been given, so we show the help:

--- a/clex.nim
+++ b/clex.nim
@@ -227,7 +227,7 @@ proc debugTok*(L: Lexer; tok: Token): string =
   if L.debugMode: result.add(" (" & $tok.xkind & ")")
 
 proc printTok(tok: Token) =
-  writeln(stdout, $tok)
+  writeline(stdout, $tok)
 
 proc matchUnderscoreChars(L: var Lexer, tok: var Token, chars: set[char]) =
   # matches ([chars]_)*

--- a/cparse.nim
+++ b/cparse.nim
@@ -240,7 +240,7 @@ proc expandMacro(p: var Parser, m: Macro) =
     new(newList)
     var lastTok = newList
     var mergeToken = false
-    template appendTok(t) {.dirty, immediate.} =
+    template appendTok(t: untyped) {.dirty.} =
       if mergeToken:
         mergeToken = false
         lastTok.s &= t.s
@@ -1014,7 +1014,7 @@ proc exprToNumber(n: PNode): tuple[succ: bool, val: BiggestInt] =
   else: discard
 
 when not declared(sequtils.any):
-  template any(x, cond: expr): expr =
+  template any(x, cond: untyped): untyped =
     var result = false
     for it {.inject.} in x:
       if cond: result = true; break
@@ -1312,7 +1312,7 @@ proc parseOperator(p: var Parser, origName: var string): bool =
   else:
     parMessage(p, errGenerated, "operator symbol expected")
 
-proc declarationName(p: var Parser): string =
+proc declarationName*(p: var Parser): string =
     when false:
       while p.tok.xkind == pxScope and pfCpp in p.options.flags:
         getTok(p) # skip "::"

--- a/cpp.nim
+++ b/cpp.nim
@@ -70,12 +70,16 @@ proc parseDefine(p: var Parser; hasParams: bool): PNode =
     result = newNodeP(nkConstSection, p)
     while true:
       var c = newNodeP(nkConstDef, p)
+      var mTokStr = p.tok.s  # name of macro for reservedMacros
       addSon(c, skipIdentExport(p, skConst))
       addSon(c, ast.emptyNode)
       skipStarCom(p, c)
       if p.tok.xkind in {pxLineComment, pxNewLine, pxEof}:
         addSon(c, newIdentNodeP("true", p))
+        p.options.reservedMacros.add(mTokStr, nil)  # empty (reserved) Macro
       else:
+        if p.tok.s.startsWith("__"):
+          p.options.reservedMacros.add(mTokStr, p.tok.s)  # reserved Macro
         addSon(c, expression(p))
       addSon(result, c)
       eatNewLine(p, c)

--- a/rules.nim
+++ b/rules.nim
@@ -33,7 +33,7 @@ proc nep1(s: string, k: TSymKind): string =
              "range", "openarray", "varargs", "set", "cfloat"]:
       result.add s[i]
     else:
-      result.add toUpper(s[i])
+      result.add toUpperAscii(s[i])
   of skConst, skEnumField:
     # for 'const' we keep how it's spelt; either upper case or lower case:
     result.add s[i]
@@ -41,7 +41,7 @@ proc nep1(s: string, k: TSymKind): string =
     # as a special rule, don't transform 'L' to 'l'
     if L == 1 and s[L-1] == 'L': result.add 'L'
     else:
-      result.add toLower(s[i])
+      result.add toLowerAscii(s[i])
   inc i
   while i < L:
     if s[i] == '_':
@@ -52,9 +52,9 @@ proc nep1(s: string, k: TSymKind): string =
         result.add('_')
         result.add s[i]
       else:
-        result.add toUpper(s[i])
+        result.add toUpperAscii(s[i])
     elif allUpper:
-      result.add toLower(s[i])
+      result.add toLowerAscii(s[i])
     else:
       result.add s[i]
     inc i

--- a/testsuite/results/emptyDefine.nim
+++ b/testsuite/results/emptyDefine.nim
@@ -1,0 +1,18 @@
+const
+  MYIGNORE* = true
+  MYCDECL* = __cdecl
+
+proc test1*(): cint =
+  var x: cint = 1
+  return x
+
+proc test2*(): cint {.cdecl.} =
+  var x: cint = 2
+  return x
+
+when defined(MYIGNORE):
+  var myVar*: cint
+  proc test3*(): cint =
+    myVar = test1()
+    myVar = myVar + test2()
+    return myVar

--- a/testsuite/tests/emptyDefine.h
+++ b/testsuite/tests/emptyDefine.h
@@ -1,0 +1,16 @@
+#define MYIGNORE
+#define MYCDECL   __cdecl
+
+int test1() { int x = 1; return (x); }
+MYCDECL int test2() { int x = 2; return (x); }
+
+#ifdef MYIGNORE
+  int myVar;
+
+  MYIGNORE int test3() {
+        myVar = test1();
+	myVar = myVar + test2();
+	return(myVar);
+  }
+
+#endif 


### PR DESCRIPTION
Add ability to handle empty macros or macros for reserved words (start with "__") in a function declaration

eg,
# define DLLSPEC1
# define DLLSPEC2  __cdecl

DLLSPEC1 int myfunc1() {
  ;
}
DLLSPEC2 int myfunc1() {
  ;
}
