### PR TITLE
Added support for #skip directive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 nimcache
 testsuite/tests/*.nim
+testsuite/tester
 c2nim.exe
+/c2nim

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,20 @@ sudo: false
 language: c
 os: linux
 install:
-  - git clone https://github.com/nim-lang/nim
-  - cd nim
-  - sh bootstrap.sh
-  - export PATH=$(pwd)/bin:$PATH
-  - nim e install_nimble.nims
-  - nimble install
+  - set -e
+  - git clone https://github.com/nim-lang/Nim
+  - cd Nim
+  - git clone --depth 1 https://github.com/nim-lang/csources.git
+  - cd csources
+  - sh build.sh
+  - cd ..
+  - export PATH=$(pwd)/bin
+  - nim c koch
+  - ./koch boot -d:release
+  - ./koch nimble
   - cd ..
 before_script:
   - set -e
-  - export PATH=$(pwd)/nim/bin:$(pwd):$PATH
+  - export PATH=$(pwd)/Nim/bin:$(pwd):$PATH
 script:
-  - nim c c2nim.nim
-  - nim c -r testsuite/tester.nim
+  - nimble tests

--- a/c2nim.nim
+++ b/c2nim.nim
@@ -13,7 +13,7 @@ import
   clex, cparse, postprocessor
 
 const
-  Version = "0.9.12" # keep in sync with Nimble version. D'oh!
+  Version = "0.9.13" # keep in sync with Nimble version. D'oh!
   Usage = """
 c2nim - C to Nim source converter
   (c) 2016 Andreas Rumpf
@@ -33,6 +33,8 @@ Options:
                          (multiple --prefix options are supported)
   --suffix:SUFFIX        strip suffix for the generated Nim identifiers
                          (multiple --suffix options are supported)
+  --skip:IDENT           skips #ifdef section for the given C identifier
+                         (multiple --skip options are supported)
   --skipinclude          do not convert ``#include`` to ``import``
   --typeprefixes         generate ``T`` and ``P`` type prefixes
   --nep1                 follow 'NEP 1': Style Guide for Nim Code
@@ -61,7 +63,7 @@ proc parse(infile: string, options: PParserOptions; dllExport: var PNode): PNode
     else:
       for x in dllprocs: dllExport.add x
 
-proc isC2nimFile(s: string): bool = splitFile(s).ext.toLower == ".c2nim"
+proc isC2nimFile(s: string): bool = splitFile(s).ext.toLowerAscii == ".c2nim"
 
 proc main(infiles: seq[string], outfile: var string,
           options: PParserOptions, concat: bool) =
@@ -116,7 +118,7 @@ for kind, key, val in getopt():
       parserOptions.exportPrefix = val
     else:
       if not parserOptions.setOption(key, val):
-        stdout.writeln("[Error] unknown option: " & key)
+        stdout.writeLine("[Error] unknown option: " & key)
   of cmdEnd: assert(false)
 if infiles.len == 0:
   # no filename has been given, so we show the help:

--- a/c2nim.nim
+++ b/c2nim.nim
@@ -33,8 +33,10 @@ Options:
                          (multiple --prefix options are supported)
   --suffix:SUFFIX        strip suffix for the generated Nim identifiers
                          (multiple --suffix options are supported)
-  --skip:IDENT           skips #ifdef section for the given C identifier
-                         (multiple --skip options are supported)
+  --skipifdef:IDENT      skips #ifdef sections for the given C identifier
+                         (multiple --skipifdef options are supported)
+  --skipifndef:IDENT     skips #ifndef sections for the given C identifier
+                         (multiple --skipifndef options are supported)
   --skipinclude          do not convert ``#include`` to ``import``
   --typeprefixes         generate ``T`` and ``P`` type prefixes
   --nep1                 follow 'NEP 1': Style Guide for Nim Code

--- a/c2nim.nim
+++ b/c2nim.nim
@@ -33,10 +33,10 @@ Options:
                          (multiple --prefix options are supported)
   --suffix:SUFFIX        strip suffix for the generated Nim identifiers
                          (multiple --suffix options are supported)
-  --skipifdef:IDENT      skips #ifdef sections for the given C identifier
-                         (multiple --skipifdef options are supported)
-  --skipifndef:IDENT     skips #ifndef sections for the given C identifier
-                         (multiple --skipifndef options are supported)
+  --assumedef:IDENT      skips #ifndef sections for the given C identifier
+                         (multiple --assumedef options are supported)
+  --assumendef:IDENT     skips #ifdef sections for the given C identifier
+                         (multiple --assumendef options are supported)
   --skipinclude          do not convert ``#include`` to ``import``
   --typeprefixes         generate ``T`` and ``P`` type prefixes
   --nep1                 follow 'NEP 1': Style Guide for Nim Code

--- a/c2nim.nimble
+++ b/c2nim.nimble
@@ -1,11 +1,13 @@
-[Package]
-name          = "c2nim"
-version       = "0.9.12"
+version       = "0.9.13"
 author        = "Andreas Rumpf"
 description   = "c2nim is a tool to translate Ansi C code to Nim."
 license       = "MIT"
+skipDirs      = @["doc"]
 
-bin = "c2nim"
+bin = @["c2nim"]
 
-[Deps]
-Requires: "nim >= 0.14.0, compiler >= 0.14.0"
+requires "nim >= 0.16.0", "compiler >= 0.16.0"
+
+task tests, "runs c2nim tests":
+  exec "nim c c2nim.nim"
+  exec "nim c --run testsuite/tester.nim"

--- a/clex.nim
+++ b/clex.nim
@@ -227,7 +227,7 @@ proc debugTok*(L: Lexer; tok: Token): string =
   if L.debugMode: result.add(" (" & $tok.xkind & ")")
 
 proc printTok(tok: Token) =
-  writeln(stdout, $tok)
+  writeLine(stdout, $tok)
 
 proc matchUnderscoreChars(L: var Lexer, tok: var Token, chars: set[char]) =
   # matches ([chars]_)*

--- a/cparse.nim
+++ b/cparse.nim
@@ -44,7 +44,7 @@ type
   ParserOptions = object ## shared parser state!
     flags: set[ParserFlag]
     prefixes, suffixes: seq[string]
-    skipped: seq[string]
+    skipIfDef, skipIfnDef: seq[string]
     mangleRules: seq[tuple[pattern: Peg, frmt: string]]
     privateRules: seq[Peg]
     dynlibSym, headerOverride: string
@@ -92,7 +92,8 @@ proc newParserOptions*(): PParserOptions =
   new(result)
   result.prefixes = @[]
   result.suffixes = @[]
-  result.skipped = @[]
+  result.skipIfDef = @["__cplusplus"]
+  result.skipIfnDef = @[]
   result.macros = @[]
   result.mangleRules = @[]
   result.privateRules = @[]
@@ -121,7 +122,8 @@ proc setOption*(parserOptions: PParserOptions, key: string, val=""): bool =
   of "stdcall": incl(parserOptions.flags, pfStdCall)
   of "prefix": parserOptions.prefixes.add(val)
   of "suffix": parserOptions.suffixes.add(val)
-  of "skip": parserOptions.skipped.add(val)
+  of "skipifdef": parserOptions.skipIfDef.add(val)
+  of "skipifndef": parserOptions.skipIfnDef.add(val)
   of "skipinclude": incl(parserOptions.flags, pfSkipInclude)
   of "typeprefixes": incl(parserOptions.flags, pfTypePrefixes)
   of "skipcomments": incl(parserOptions.flags, pfSkipComments)

--- a/cparse.nim
+++ b/cparse.nim
@@ -44,7 +44,7 @@ type
   ParserOptions = object ## shared parser state!
     flags: set[ParserFlag]
     prefixes, suffixes: seq[string]
-    skipIfDef, skipIfnDef: seq[string]
+    assumeDef, assumenDef: seq[string]
     mangleRules: seq[tuple[pattern: Peg, frmt: string]]
     privateRules: seq[Peg]
     dynlibSym, headerOverride: string
@@ -92,8 +92,8 @@ proc newParserOptions*(): PParserOptions =
   new(result)
   result.prefixes = @[]
   result.suffixes = @[]
-  result.skipIfDef = @["__cplusplus"]
-  result.skipIfnDef = @[]
+  result.assumeDef = @[]
+  result.assumenDef = @["__cplusplus"]
   result.macros = @[]
   result.mangleRules = @[]
   result.privateRules = @[]
@@ -122,8 +122,8 @@ proc setOption*(parserOptions: PParserOptions, key: string, val=""): bool =
   of "stdcall": incl(parserOptions.flags, pfStdCall)
   of "prefix": parserOptions.prefixes.add(val)
   of "suffix": parserOptions.suffixes.add(val)
-  of "skipifdef": parserOptions.skipIfDef.add(val)
-  of "skipifndef": parserOptions.skipIfnDef.add(val)
+  of "assumedef": parserOptions.assumeDef.add(val)
+  of "assumendef": parserOptions.assumenDef.add(val)
   of "skipinclude": incl(parserOptions.flags, pfSkipInclude)
   of "typeprefixes": incl(parserOptions.flags, pfTypePrefixes)
   of "skipcomments": incl(parserOptions.flags, pfSkipComments)

--- a/cparse.nim
+++ b/cparse.nim
@@ -44,6 +44,7 @@ type
   ParserOptions = object ## shared parser state!
     flags: set[ParserFlag]
     prefixes, suffixes: seq[string]
+    skipped: seq[string]
     mangleRules: seq[tuple[pattern: Peg, frmt: string]]
     privateRules: seq[Peg]
     dynlibSym, headerOverride: string
@@ -91,6 +92,7 @@ proc newParserOptions*(): PParserOptions =
   new(result)
   result.prefixes = @[]
   result.suffixes = @[]
+  result.skipped = @[]
   result.macros = @[]
   result.mangleRules = @[]
   result.privateRules = @[]
@@ -119,6 +121,7 @@ proc setOption*(parserOptions: PParserOptions, key: string, val=""): bool =
   of "stdcall": incl(parserOptions.flags, pfStdCall)
   of "prefix": parserOptions.prefixes.add(val)
   of "suffix": parserOptions.suffixes.add(val)
+  of "skip": parserOptions.skipped.add(val)
   of "skipinclude": incl(parserOptions.flags, pfSkipInclude)
   of "typeprefixes": incl(parserOptions.flags, pfTypePrefixes)
   of "skipcomments": incl(parserOptions.flags, pfSkipComments)

--- a/cpp.nim
+++ b/cpp.nim
@@ -308,10 +308,8 @@ proc parseIfDir(p: var Parser; sectionParser: SectionParser): PNode =
     result = ast.emptyNode
   else:
     addSon(result.sons[0], condition)
-    echo "sons -> ", condition
     eatNewLine(p, nil)
     parseIfDirAux(p, result, sectionParser)
-    echo "result: ", result
     if pfAssumeIfIsTrue in p.options.flags:
       result = result.sons[0].sons[1]
 

--- a/cpp.nim
+++ b/cpp.nim
@@ -307,11 +307,9 @@ proc definedGuard(n: PNode): string =
 # we can substitute `defined(IDENT)` with `true`
 # Then, boolean conditions are simplified recursively as far as possible
 proc simplify(p: Parser, n: PNode): PNode =
-  var
-    trueNode = newNodeP(nkIdent, p)
-    falseNode = newNodeP(nkIdent, p)
-  trueNode.ident = getIdent("true")
-  falseNode.ident = getIdent("false")
+  let
+    trueNode = newIdentNodeP("true", p)
+    falseNode = newIdentNodeP("false", p)
 
   case n.kind
   of nkCall:

--- a/cpp.nim
+++ b/cpp.nim
@@ -223,6 +223,9 @@ proc skipUntilElifElseEndif(p: var Parser): TEndifMarker =
     getTok(p)
   parMessage(p, errXExpected, "#endif")
 
+# Returns `true` if there is a declaration
+#   #assumedef `s`
+# or there is a macro with name `s`.
 proc defines(p: Parser, s: string): bool =
   if p.options.assumeDef.contains(s): return true
   for m in p.options.macros:
@@ -307,11 +310,11 @@ proc definedGuard(n: PNode): string =
 
 # Simplifies a condition based on the following assumptions:
 # - if there is a declaration
-#   #skipifdef IDENT
-# we can substitute `defined(IDENT)` with `false`
-# - if there is a declaration
-#   #skipifndef IDENT
+#   #assumedef IDENT
 # we can substitute `defined(IDENT)` with `true`
+# - if there is a declaration
+#   #assumendef IDENT
+# we can substitute `defined(IDENT)` with `false`
 # Then, boolean conditions are simplified recursively as far as possible
 proc simplify(p: Parser, n: PNode): PNode =
   let

--- a/cpp.nim
+++ b/cpp.nim
@@ -289,47 +289,85 @@ proc parseIfndef(p: var Parser; sectionParser: SectionParser): PNode =
       addSon(result.sons[0], e)
       parseIfDirAux(p, result, sectionParser)
 
+proc isIdent(n: PNode, id: string): bool =
+  n.kind == nkIdent and n.ident.s == id
+
 proc definedGuard(n: PNode): string =
   if n.len == 2:
     let call = n.sons[0]
-    if call.kind == nkIdent and call.ident.s == "defined":
+    if call.isIdent("defined"):
       result = n.sons[1].ident.s
 
-proc shouldSkip(p: Parser, n: PNode): bool =
+# Simplifies a condition based on the following assumptions:
+# - if there is a declaration
+#   #skipifdef IDENT
+# we can substitute `defined(IDENT)` with `false`
+# - if there is a declaration
+#   #skipifndef IDENT
+# we can substitute `defined(IDENT)` with `true`
+# Then, boolean conditions are simplified recursively as far as possible
+proc simplify(p: Parser, n: PNode): PNode =
+  var
+    trueNode = newNodeP(nkIdent, p)
+    falseNode = newNodeP(nkIdent, p)
+  trueNode.ident = getIdent("true")
+  falseNode.ident = getIdent("false")
+
   case n.kind
   of nkCall:
     let guard = definedGuard(n)
-    result = p.options.skipIfDef.contains(guard)
+    if p.options.skipIfDef.contains(guard):
+      return falseNode
+    if p.options.skipIfnDef.contains(guard):
+      return trueNode
   of nkInfix:
     let op = n.sons[0]
-    if op.kind == nkIdent and op.ident.s == "and":
-      result = true
+    if op.isIdent("and"):
+      # subconditions can be true, false or unknown
+      var allTrue = true
       for i in 1 ..< n.len:
-        if not p.shouldSkip(n.sons[i]):
-          result = false
-    elif op.kind == nkIdent and op.ident.s == "or":
-      result = false
+        let n1 = p.simplify(n.sons[i])
+        if n1.isIdent("true"):
+          discard
+        elif n1.isIdent("false"):
+          return falseNode
+        else:
+          allTrue = false
+      if allTrue:
+        return trueNode
+    elif op.isIdent("or"):
+      # subconditions can be true, false or unknown
+      var allFalse = true
       for i in 1 ..< n.len:
-        if p.shouldSkip(n.sons[i]):
-          result = true
-    else:
-      result = false
+        let n1 = p.simplify(n.sons[i])
+        if n1.isIdent("true"):
+          return trueNode
+        elif n1.isIdent("false"):
+          discard
+        else:
+          allFalse = false
+      if allFalse:
+        return falseNode
   of nkPrefix:
-    let op = n.sons[0]
-    if op.kind == nkIdent and op.ident.s == "not":
-      let guard = definedGuard(n.sons[1])
-      result = p.options.skipIfnDef.contains(guard)
-    else:
-      result = false
+    if n.len == 2:
+      let
+        op = n.sons[0]
+        n1 = p.simplify(n.sons[1])
+      if op.isIdent("not"):
+        if n1.isIdent("true"):
+          return falseNode
+        if n1.isIdent("false"):
+          return trueNode
   else:
-    result = false
+    discard
+  return n
 
 proc parseIfDir(p: var Parser; sectionParser: SectionParser): PNode =
   result = newNodeP(nkWhenStmt, p)
   addSon(result, newNodeP(nkElifBranch, p))
   getTok(p)
   let condition = expression(p)
-  if p.shouldSkip(condition):
+  if p.simplify(condition).isIdent("false"):
     skipUntilEndif(p)
     result = ast.emptyNode
   else:

--- a/cpp.nim
+++ b/cpp.nim
@@ -224,7 +224,7 @@ proc skipUntilElifElseEndif(p: var Parser): TEndifMarker =
   parMessage(p, errXExpected, "#endif")
 
 proc parseIfdef(p: var Parser; sectionParser: SectionParser): PNode =
-  getTok(p) # skip #ifdef
+  rawGetTok(p) # skip #ifdef
   expectIdent(p)
   if p.options.skipIfDef.contains(p.tok.s):
     skipUntilEndif(p)
@@ -251,7 +251,7 @@ proc isIncludeGuard(p: var Parser): bool =
 
 proc parseIfndef(p: var Parser; sectionParser: SectionParser): PNode =
   result = ast.emptyNode
-  getTok(p) # skip #ifndef
+  rawGetTok(p) # skip #ifndef
   expectIdent(p)
   if p.options.skipIfnDef.contains(p.tok.s):
     skipUntilEndif(p)

--- a/doc/c2nim.rst
+++ b/doc/c2nim.rst
@@ -231,6 +231,31 @@ too, there is no need to quote them:
   // is short for:
   #mangle "'ssize_t'" "int"
 
+``#skip`` directive
+--------------------------------------
+
+**Note**: There is also a ``--skip`` command line option that can be used for
+the same purpose.
+
+c2nim can be configured to skip certain ``#ifdef`` sections. For instance,
+the following directive
+
+.. code-block:: C
+  #skip NVGRAPH_API
+
+can be used to ignore the whole code block
+
+.. code-block:: C
+  #ifndef NVGRAPH_API
+  #ifdef _WIN32
+  #define NVGRAPH_API __stdcall
+  #else
+  #define NVGRAPH_API
+  #endif
+  #endif
+
+which may otherwise confuse the c2nim parser.
+
 
 ``#private`` directive
 ----------------------

--- a/doc/c2nim.rst
+++ b/doc/c2nim.rst
@@ -231,17 +231,27 @@ too, there is no need to quote them:
   // is short for:
   #mangle "'ssize_t'" "int"
 
-``#skipifdef`` and ``#skipifndef`` directives
+``#assumedef`` and ``#assumendef`` directives
 ----------------------------------------------
 
-**Note**: There are also ``--skipifdef`` and ``--skipifndef`` command line
+**Note**: There are also ``--assumedef`` and ``--assumendef`` command line
 options that can be used for the same purpose.
 
 c2nim can be configured to skip certain ``#ifdef`` or ``#ifndef`` sections.
+If a directive ``#assumedef SYMBOL``is found, c2nim will assume that the symbol
+``SYMBOL`` is defined, and thus skip ``#ifndef SYMBOL`` sections. The same
+happens if ``SYMBOL`` is actually defined with a ``#def`` directive.
+
+Viceversa, one can also use ``#assumendef SYMBOL`` to declare that ``SYMBOL``
+should be considered not defined, and hence skip ``#ifdef SYMBOL`` sections.
+
+These features also work for declarations like ``#if defined(SYMBOL)`` and
+boolean combinations of such declarations.
+
 For instance, the following directive
 
 .. code-block:: C
-  #skipifndef NVGRAPH_API
+  #assumedef NVGRAPH_API
 
 can be used to ignore the whole code block
 

--- a/doc/c2nim.rst
+++ b/doc/c2nim.rst
@@ -231,17 +231,17 @@ too, there is no need to quote them:
   // is short for:
   #mangle "'ssize_t'" "int"
 
-``#skip`` directive
---------------------------------------
+``#skipifdef`` and ``#skipifndef`` directives
+----------------------------------------------
 
-**Note**: There is also a ``--skip`` command line option that can be used for
-the same purpose.
+**Note**: There are also ``--skipifdef`` and ``--skipifndef`` command line
+options that can be used for the same purpose.
 
-c2nim can be configured to skip certain ``#ifdef`` sections. For instance,
-the following directive
+c2nim can be configured to skip certain ``#ifdef`` or ``#ifndef`` sections.
+For instance, the following directive
 
 .. code-block:: C
-  #skip NVGRAPH_API
+  #skipifndef NVGRAPH_API
 
 can be used to ignore the whole code block
 

--- a/rules.nim
+++ b/rules.nim
@@ -33,7 +33,7 @@ proc nep1(s: string, k: TSymKind): string =
              "range", "openarray", "varargs", "set", "cfloat"]:
       result.add s[i]
     else:
-      result.add toUpper(s[i])
+      result.add toUpperAscii(s[i])
   of skConst, skEnumField:
     # for 'const' we keep how it's spelt; either upper case or lower case:
     result.add s[i]
@@ -41,7 +41,7 @@ proc nep1(s: string, k: TSymKind): string =
     # as a special rule, don't transform 'L' to 'l'
     if L == 1 and s[L-1] == 'L': result.add 'L'
     else:
-      result.add toLower(s[i])
+      result.add toLowerAscii(s[i])
   inc i
   while i < L:
     if s[i] == '_':
@@ -52,9 +52,9 @@ proc nep1(s: string, k: TSymKind): string =
         result.add('_')
         result.add s[i]
       else:
-        result.add toUpper(s[i])
+        result.add toUpperAscii(s[i])
     elif allUpper:
-      result.add toLower(s[i])
+      result.add toLowerAscii(s[i])
     else:
       result.add s[i]
     inc i

--- a/testsuite/results/skipsection.nim
+++ b/testsuite/results/skipsection.nim
@@ -1,6 +1,12 @@
 when defined(skipme1):
   const
     thisShouldNotBeSkipped* = 1
+when defined(skipme) and defined(somethingelse):
+  const
+    thisShouldBePresent* = 1
+when defined(somethingelse) and not defined(skipme1):
+  const
+    oneMoreConstant* = 1
 type
   foo* = object
     x*: cint

--- a/testsuite/results/skipsection.nim
+++ b/testsuite/results/skipsection.nim
@@ -1,0 +1,5 @@
+type
+  foo* = object
+    x*: cint
+    y*: cint
+    z*: cint

--- a/testsuite/results/skipsection.nim
+++ b/testsuite/results/skipsection.nim
@@ -1,10 +1,10 @@
 when defined(skipme1):
   const
     thisShouldNotBeSkipped* = 1
-when defined(skipme) and defined(somethingelse):
+when defined(skipme) or defined(somethingelse):
   const
     thisShouldBePresent* = 1
-when defined(somethingelse) and not defined(skipme1):
+when not defined(skipme1) or defined(somethingelse):
   const
     oneMoreConstant* = 1
 type

--- a/testsuite/results/skipsection.nim
+++ b/testsuite/results/skipsection.nim
@@ -1,3 +1,6 @@
+when defined(skipme1):
+  const
+    thisShouldNotBeSkipped* = 1
 type
   foo* = object
     x*: cint

--- a/testsuite/tester.nim
+++ b/testsuite/tester.nim
@@ -3,8 +3,8 @@
 import strutils, os
 
 const
-  c2nimCmd = "c2nim $#"
-  cpp2nimCmd = "c2nim --cpp $#"
+  c2nimCmd = "./c2nim $#"
+  cpp2nimCmd = "./c2nim --cpp $#"
   dir = "testsuite/"
 
 var

--- a/testsuite/tester.nim
+++ b/testsuite/tester.nim
@@ -3,8 +3,8 @@
 import strutils, os
 
 const
-  c2nimCmd = "./c2nim $#"
-  cpp2nimCmd = "./c2nim --cpp $#"
+  c2nimCmd = "c2nim $#"
+  cpp2nimCmd = "c2nim --cpp $#"
   dir = "testsuite/"
 
 var

--- a/testsuite/tests/skipsection.h
+++ b/testsuite/tests/skipsection.h
@@ -1,4 +1,5 @@
-#skip skipme
+#skipifdef skipme
+#skipifndef skipme1
 
 #ifdef skipme
 #ifdef innerifdef
@@ -8,8 +9,12 @@
 #endif
 #endif
 
-#ifndef skipme
+#ifndef skipme1
 #define thisShouldAlsoBeSkipped 1
+#endif
+
+#ifdef skipme1
+#define thisShouldNotBeSkipped 1
 #endif
 
 #if defined(skipme)

--- a/testsuite/tests/skipsection.h
+++ b/testsuite/tests/skipsection.h
@@ -8,6 +8,10 @@
 #endif
 #endif
 
+#ifndef skipme
+#define thisShouldAlsoBeSkipped 1
+#endif
+
 #if defined(skipme)
 #define thisShouldAlsoBeSkipped 1
 #endif

--- a/testsuite/tests/skipsection.h
+++ b/testsuite/tests/skipsection.h
@@ -8,6 +8,14 @@
 #endif
 #endif
 
+#if defined(skipme)
+#define thisShouldAlsoBeSkipped 1
+#endif
+
+#if defined(__cplusplus)
+#define skipMeAsWell 1
+#endif
+
 struct foo {
     int x,y,z;
 };

--- a/testsuite/tests/skipsection.h
+++ b/testsuite/tests/skipsection.h
@@ -1,0 +1,13 @@
+#skip skipme
+
+#ifdef skipme
+#ifdef innerifdef
+#define foo bar
+#else
+#define foo baz
+#endif
+#endif
+
+struct foo {
+    int x,y,z;
+};

--- a/testsuite/tests/skipsection.h
+++ b/testsuite/tests/skipsection.h
@@ -1,5 +1,8 @@
 #skipifdef skipme
 #skipifndef skipme1
+#skipifdef skipme2
+
+#def skipme2 somethingelse
 
 #ifdef skipme
 #ifdef innerifdef
@@ -15,6 +18,10 @@
 
 #ifdef skipme1
 #define thisShouldNotBeSkipped 1
+#endif
+
+#ifdef skipme2
+#define thisShouldBeSkipped 1
 #endif
 
 #if defined(skipme)

--- a/testsuite/tests/skipsection.h
+++ b/testsuite/tests/skipsection.h
@@ -33,19 +33,19 @@
 #endif
 
 #if defined(skipme) || defined(somethingelse)
-#define thisShouldAlsoBeSkipped 1
-#endif
-
-#if defined(skipme) && defined(somethingelse)
 #define thisShouldBePresent 1
 #endif
 
-#if !defined(skipme1) || defined(somethingelse)
+#if defined(skipme) && defined(somethingelse)
 #define thisShouldAlsoBeSkipped 1
 #endif
 
-#if defined(somethingelse) && !defined(skipme1)
+#if !defined(skipme1) || defined(somethingelse)
 #define oneMoreConstant 1
+#endif
+
+#if defined(somethingelse) && !defined(skipme1)
+#define thisShouldAlsoBeSkipped 1
 #endif
 
 struct foo {

--- a/testsuite/tests/skipsection.h
+++ b/testsuite/tests/skipsection.h
@@ -32,6 +32,22 @@
 #define skipMeAsWell 1
 #endif
 
+#if defined(skipme) || defined(somethingelse)
+#define thisShouldAlsoBeSkipped 1
+#endif
+
+#if defined(skipme) && defined(somethingelse)
+#define thisShouldBePresent 1
+#endif
+
+#if !defined(skipme1) || defined(somethingelse)
+#define thisShouldAlsoBeSkipped 1
+#endif
+
+#if defined(somethingelse) && !defined(skipme1)
+#define oneMoreConstant 1
+#endif
+
 struct foo {
     int x,y,z;
 };

--- a/testsuite/tests/skipsection.h
+++ b/testsuite/tests/skipsection.h
@@ -1,6 +1,5 @@
-#skipifdef skipme
-#skipifndef skipme1
-#skipifdef skipme2
+#assumendef skipme
+#assumedef skipme1
 
 #def skipme2 somethingelse
 
@@ -20,7 +19,7 @@
 #define thisShouldNotBeSkipped 1
 #endif
 
-#ifdef skipme2
+#ifndef skipme2
 #define thisShouldBeSkipped 1
 #endif
 


### PR DESCRIPTION
I have added a new directive (`#skip`) which can instruct c2nim to skip certain `#ifdef` blocks altogether.

In doing so, I have done some minor cleanup (removed some deprecation errors, and moved the nimble file to nimscript, while adding a `tests` task).