### PR TITLE
Handle qualified return type in operator overload signature

### DIFF
--- a/testsuite/results/cpp11.nim
+++ b/testsuite/results/cpp11.nim
@@ -3,3 +3,4 @@ type
   
 
 proc constructEvent*(): Event {.constructor.}
+proc `<<`*(`out`: var ostream; t: Enum): var ostream

--- a/testsuite/tests/cpp11.cpp
+++ b/testsuite/tests/cpp11.cpp
@@ -4,3 +4,4 @@ public:
   Event() = default;
 };
 
+std::ostream &operator << (std::ostream &out, const Enum &t);


### PR DESCRIPTION
c2nim can now parse this: `std::ostream &operator << (std::ostream &out, const Enum &t);`
It was failing to recognize a declaration due to the  `::` scope token.