### PR TITLE
[bugfix] update for 0.20.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
     - "$HOME/.choosenim"
 
 env:
-  - CHOOSENIM_CHOOSE_VERSION="0.19.0"
+  - CHOOSENIM_CHOOSE_VERSION="0.20.0"
 
 install:
   - |

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,0 +1,1 @@
+-d:nimOldCaseObjects

--- a/testsuite/results/bug107_108.nim
+++ b/testsuite/results/bug107_108.nim
@@ -1,5 +1,5 @@
 type
-  Foo* {.bycopy.}[I: static[cint]; B: static[bool]] = object
+  Foo*[I: static[cint]; B: static[bool]] {.bycopy.} = object
 
 
 proc `method`*[I: static[cint]; B: static[bool]](this: var Foo[I, B]; i: cint)

--- a/testsuite/results/smartptrs.nim
+++ b/testsuite/results/smartptrs.nim
@@ -26,7 +26,7 @@ import
 ## / Shared pointer template class with intrusive reference counting.
 
 type
-  SharedPtr* {.bycopy.}[T] = object ## / Construct a null shared pointer.
+  SharedPtr*[T] {.bycopy.} = object ## / Construct a null shared pointer.
                                 ## / Prevent direct assignment from a shared pointer of another type.
 
 
@@ -63,7 +63,7 @@ proc DynamicCast*[T; U](`ptr`: SharedPtr[U]): SharedPtr[T] =
 ## / Weak pointer template class with intrusive reference counting. Does not keep the object pointed to alive.
 
 type
-  WeakPtr* {.bycopy.}[T] = object ## / Construct a null weak pointer.
+  WeakPtr*[T] {.bycopy.} = object ## / Construct a null weak pointer.
                               ## / Prevent direct assignment from a weak pointer of different type.
     ## / Pointer to the RefCount structure.
 


### PR DESCRIPTION
1. c2nim has a couple case object transitions, use `-d:nimOldCaseObjects` until `c2nim/cparser` and `nim/ast` are updated.
2. type pragma placement changed.