### PR TITLE
Skips C++11 List initializers in headers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 nimcache
 testsuite/tests/*.nim
 testsuite/tester
-c2nim.exe
+*.exe
 /c2nim

--- a/cparse.nim
+++ b/cparse.nim
@@ -1306,6 +1306,22 @@ proc parseVarDecl(p: var Parser, baseTyp, typ: PNode,
     addSon(def, parseTypeSuffix(p, t))
     addInitializer(p, def)
     addSon(result, def)
+
+  if p.options.useHeader and p.options.flags.contains(pfCpp):
+    var unmatched_braces = 0
+    while true: # skip c++11 list initializer
+      if p.tok.xkind == pxCurlyLe:
+        eat(p, pxCurlyLe)
+        inc unmatched_braces
+        continue
+      elif p.tok.xkind == pxCurlyRi:
+        eat(p, pxCurlyRi)
+        dec unmatched_braces
+        continue
+      if unmatched_braces == 0:
+        break
+      # consume initalizer list contents
+      getTok(p, nil)
   eat(p, pxSemicolon)
 
 proc parseOperator(p: var Parser, origName: var string): bool =

--- a/cparse.nim
+++ b/cparse.nim
@@ -430,10 +430,11 @@ proc statement(p: var Parser): PNode
 proc declKeyword(p: Parser, s: string): bool =
   # returns true if it is a keyword that introduces a declaration
   case s
-  of  "extern", "static", "auto", "register", "const", "volatile", "restrict",
-      "inline", "__inline", "__cdecl", "__stdcall", "__syscall", "__fastcall",
-      "__safecall", "void", "struct", "union", "enum", "typedef", "size_t",
-      "short", "int", "long", "float", "double", "signed", "unsigned", "char":
+  of  "extern", "static", "auto", "register", "const", "constexpr", "volatile", 
+      "restrict", "inline", "__inline", "__cdecl", "__stdcall", "__syscall", 
+      "__fastcall", "__safecall", "void", "struct", "union", "enum", "typedef", 
+      "size_t", "short", "int", "long", "float", "double", "signed", "unsigned",
+      "char":
     result = true
   of "class", "mutable":
     result = p.options.flags.contains(pfCpp)
@@ -458,8 +459,9 @@ proc isIntType(s: string): bool =
 
 proc skipConst(p: var Parser): bool {.discardable.} =
   while p.tok.xkind == pxSymbol and
-      (p.tok.s == "const" or p.tok.s == "volatile" or p.tok.s == "restrict" or
-       (p.tok.s == "mutable" and pfCpp in p.options.flags)):
+      (p.tok.s == "const" or p.tok.s == "constexpr" or p.tok.s == "volatile" or 
+       p.tok.s == "restrict" or (p.tok.s == "mutable" and 
+        pfCpp in p.options.flags)):
     if p.tok.s == "const": result = true
     getTok(p, nil)
 
@@ -1249,7 +1251,7 @@ proc parseTypeDef(p: var Parser): PNode =
 proc skipDeclarationSpecifiers(p: var Parser) =
   while p.tok.xkind == pxSymbol:
     case p.tok.s
-    of "extern", "static", "auto", "register", "const", "volatile":
+    of "extern", "static", "auto", "register", "const", "constexpr", "volatile":
       getTok(p, nil)
     of "mutable":
       if pfCpp in p.options.flags: getTok(p, nil)
@@ -2430,6 +2432,10 @@ proc parseClass(p: var Parser; isStruct: bool;
       if p.tok.xkind == pxSymbol and p.tok.s == "static":
         getTok(p, stmtList)
         isStatic = true
+      # skip constexpr for now
+      if p.tok.xkind == pxSymbol and p.tok.s == "constexpr":
+        getTok(p, stmtList)
+
       parseCallConv(p, pragmas)
       if p.tok.xkind == pxSymbol and p.tok.s == p.currentClassOrig and
           followedByParLe(p):

--- a/testsuite/results/constructorcall.nim
+++ b/testsuite/results/constructorcall.nim
@@ -9,3 +9,8 @@ proc bar*(f: foo = constructfoo(0)): cint =
   discard
 
 proc bar*(f: fooBar = constructfooBar(0)): cint
+type
+  ConsInitList* {.bycopy.} = object of foo
+
+
+proc constructConsInitList*(i: cint): ConsInitList {.constructor.}

--- a/testsuite/results/cpp11.nim
+++ b/testsuite/results/cpp11.nim
@@ -1,6 +1,17 @@
 type
-  Event* {.bycopy.} = object
+  Event* {.importcpp: "Event", header: "cpp11.hpp", bycopy.} = object
 
 
-proc constructEvent*(): Event {.constructor.}
-proc `<<`*(`out`: var ostream; t: Enum): var ostream
+proc constructEvent*(): Event {.constructor, importcpp: "Event(@)",
+                             header: "cpp11.hpp".}
+proc `<<`*(`out`: var ostream; t: Enum): var ostream {.importcpp: "(# << #)",
+    header: "cpp11.hpp".}
+var foo* {.importcpp: "foo", header: "cpp11.hpp".}: Event
+
+type
+  ConstexprConstructor* {.importcpp: "ConstexprConstructor", header: "cpp11.hpp",
+                         bycopy.} = object
+
+
+proc constructConstexprConstructor*(i: cint = 1): ConstexprConstructor {.constructor,
+    importcpp: "ConstexprConstructor(@)", header: "cpp11.hpp".}

--- a/testsuite/results/cpp11.nim
+++ b/testsuite/results/cpp11.nim
@@ -15,3 +15,5 @@ type
 
 proc constructConstexprConstructor*(i: cint = 1): ConstexprConstructor {.constructor,
     importcpp: "ConstexprConstructor(@)", header: "cpp11.hpp".}
+# list initialization, issue #163
+var list_init*{.importcpp: "list_init", header: "cpp11.hpp".}: int

--- a/testsuite/results/cpp11.nim
+++ b/testsuite/results/cpp11.nim
@@ -15,5 +15,6 @@ type
 
 proc constructConstexprConstructor*(i: cint = 1): ConstexprConstructor {.constructor,
     importcpp: "ConstexprConstructor(@)", header: "cpp11.hpp".}
-# list initialization, issue #163
-var list_init*{.importcpp: "list_init", header: "cpp11.hpp".}: int
+##  list initialization, issue #163
+
+var list_init* {.importcpp: "list_init", header: "cpp11.hpp".}: cint

--- a/testsuite/tester.nim
+++ b/testsuite/tester.nim
@@ -21,6 +21,7 @@ var
   failures = 0
   exit_early = false
   infiles = newSeq[string](0)
+  diff_tool = "diff -uNdr"
 
 for kind, key, val in getopt():
   case kind
@@ -31,6 +32,8 @@ for kind, key, val in getopt():
     of "help", "h":
       stdout.write(usage)
       exit_early = true
+    of "diff", "d":
+      diff_tool = val
   else:
     stdout.writeLine("[Error] unknown option: " & key)
 
@@ -42,7 +45,7 @@ proc test(t, cmd: string) =
   let nimFile = name & ".nim"
   if readFile(dir & "tests" / nimFile) != readFile(dir & "results" / nimFile):
     echo "FAILURE: files differ: ", nimFile
-    discard execShellCmd("diff -uNdr " & dir & "results" / nimFile & " " & dir & "tests" / nimFile)
+    discard execShellCmd(diff_tool & " " & dir & "results" / nimFile & " " & dir & "tests" / nimFile)
     failures += 1
     when false:
       copyFile(dir & "tests" / nimFile, dir & "results" / nimFile)

--- a/testsuite/tester.nim
+++ b/testsuite/tester.nim
@@ -1,19 +1,45 @@
 # Small program that runs the test cases
 
-import strutils, os
+import strutils, os, parseopt
 
 const
   c2nimCmd = "c2nim $#"
   cpp2nimCmd = "c2nim --cpp $#"
   hpp2nimCmd = "c2nim --cpp --header $#"
   dir = "testsuite/"
+  usage = """
+c2nim test runner
+Usage: tester testnames [options]
+  Runs all tests by default without any arguments given.
+  If testnames are given, all othere tests will be skipped. Testnames are the 
+  test file names without extension.
+Options:
+  -h --help        Shows this help
+"""
 
 var
   failures = 0
+  exit_early = false
+  infiles = newSeq[string](0)
+
+for kind, key, val in getopt():
+  case kind
+  of cmdArgument:
+    infiles.add key
+  of cmdLongOption, cmdShortOption:
+    case key.normalize
+    of "help", "h":
+      stdout.write(usage)
+      exit_early = true
+  else:
+    stdout.writeLine("[Error] unknown option: " & key)
 
 proc test(t, cmd: string) =
+  let (_, name, _) = splitFile(t)
+  if infiles.len() > 0 and not (name in infiles):
+    return
   if execShellCmd(cmd % t) != 0: quit("FAILURE")
-  let nimFile = splitFile(t).name & ".nim"
+  let nimFile = name & ".nim"
   if readFile(dir & "tests" / nimFile) != readFile(dir & "results" / nimFile):
     echo "FAILURE: files differ: ", nimFile
     discard execShellCmd("diff -uNdr " & dir & "results" / nimFile & " " & dir & "tests" / nimFile)
@@ -23,9 +49,14 @@ proc test(t, cmd: string) =
   else:
     echo "SUCCESS: files identical: ", nimFile
 
-for t in walkFiles(dir & "tests/*.c"): test(t, c2nimCmd)
-for t in walkFiles(dir & "tests/*.h"): test(t, c2nimCmd)
-for t in walkFiles(dir & "tests/*.cpp"): test(t, cpp2nimCmd)
-for t in walkFiles(dir & "tests/*.hpp"): test(t, hpp2nimCmd)
+if not exit_early:
+  for t in walkFiles(dir & "tests/*.c"): 
+    test(t, c2nimCmd)
+  for t in walkFiles(dir & "tests/*.h"): 
+    test(t, c2nimCmd)
+  for t in walkFiles(dir & "tests/*.cpp"): 
+    test(t, cpp2nimCmd)
+  for t in walkFiles(dir & "tests/*.hpp"): 
+    test(t, hpp2nimCmd)
 
-if failures > 0: quit($failures & " failures occurred.")
+  if failures > 0: quit($failures & " failures occurred.")

--- a/testsuite/tests/constructorcall.cpp
+++ b/testsuite/tests/constructorcall.cpp
@@ -14,3 +14,8 @@ int bar(foo f = foo(0)){
 
 
 int bar(fooBar f = fooBar(0));
+
+class ConsInitList : public foo{
+public:
+  ConsInitList(int i) : foo(i) {}
+};

--- a/testsuite/tests/cpp11.cpp
+++ b/testsuite/tests/cpp11.cpp
@@ -1,7 +1,0 @@
-class Event
-{
-public:
-  Event() = default;
-};
-
-std::ostream &operator << (std::ostream &out, const Enum &t);

--- a/testsuite/tests/cpp11.hpp
+++ b/testsuite/tests/cpp11.hpp
@@ -1,0 +1,14 @@
+class Event
+{
+public:
+  Event() = default;
+};
+
+std::ostream &operator << (std::ostream &out, const Enum &t);
+
+constexpr Event foo;
+
+class ConstexprConstructor {
+  public:
+  constexpr ConstexprConstructor(int i = 1) : id(i) {}
+};

--- a/testsuite/tests/cpp11.hpp
+++ b/testsuite/tests/cpp11.hpp
@@ -12,3 +12,5 @@ class ConstexprConstructor {
   public:
   constexpr ConstexprConstructor(int i = 1) : id(i) {}
 };
+// list initialization, issue #163
+constexpr int list_init{123};


### PR DESCRIPTION
Fixed #163 

Merge the constexpr PR first.