### PR TITLE
fix parsing of continuous directives in struct:

### DIFF
--- a/cparse.nim
+++ b/cparse.nim
@@ -796,7 +796,10 @@ proc parseStructBody(p: var Parser, stmtList: PNode, isUnion: bool,
     elif p.tok.xkind == pxDirective or p.tok.xkind == pxDirectiveParLe:
       var define = parseDir(p, statement)
       addSon(result, define)
-      baseTyp = typeAtom(p)
+      if p.tok.xkind == pxSymbol:
+        baseTyp = typeAtom(p)
+      else:
+        continue
     else:
       baseTyp = typeAtom(p)
 

--- a/testsuite/results/struct_directives.nim
+++ b/testsuite/results/struct_directives.nim
@@ -1,0 +1,7 @@
+type
+  test* {.bycopy.} = object
+    when defined(A):
+      var a*: cint
+    when defined(B):
+      var b*: cint
+

--- a/testsuite/tests/struct_directives.h
+++ b/testsuite/tests/struct_directives.h
@@ -1,0 +1,8 @@
+struct test {
+#ifdef A
+  int a;
+#endif
+#ifdef B
+  int b;
+#endif
+};


### PR DESCRIPTION
struct ...
{
#ifdef A
    int a;
#endif
#ifdef B
    int b;
#endif
} ..;