### PR TITLE
add a new option: annotate procs with `{.noconv.}`

### DIFF
--- a/c2nim.nim
+++ b/c2nim.nim
@@ -30,6 +30,7 @@ Options:
   --header:HEADER_FILE   import from a HEADER_FILE (discouraged!)
   --header               import from the given header file
   --cdecl                annotate procs with ``{.cdecl.}``
+  --noconv               annotate procs with ``{.noconv.}``
   --stdcall              annotate procs with ``{.stdcall.}``
   --ref                  convert typ* to ref typ (default: ptr typ)
   --prefix:PREFIX        strip prefix for the generated Nim identifiers

--- a/cparse.nim
+++ b/cparse.nim
@@ -33,6 +33,7 @@ type
     pfRefs,             ## use "ref" instead of "ptr" for C's typ*
     pfCDecl,            ## annotate procs with cdecl
     pfStdCall,          ## annotate procs with stdcall
+    pfNoConv,           ## annotate procs with noconv
     pfSkipInclude,      ## skip all ``#include``
     pfTypePrefixes,     ## all generated types start with 'T' or 'P'
     pfSkipComments,     ## do not generate comments
@@ -128,6 +129,7 @@ proc setOption*(parserOptions: PParserOptions, key: string, val=""): bool =
     if val.len > 0: parserOptions.headerOverride = val
   of "cdecl": incl(parserOptions.flags, pfCdecl)
   of "stdcall": incl(parserOptions.flags, pfStdCall)
+  of "noconv": incl(parserOptions.flags, pfNoConv)
   of "prefix": parserOptions.prefixes.add(val)
   of "suffix": parserOptions.suffixes.add(val)
   of "paramprefix":
@@ -624,6 +626,8 @@ proc newProcPragmas(p: Parser): PNode =
     addSon(result, newIdentNodeP("cdecl", p))
   elif pfStdCall in p.options.flags:
     addSon(result, newIdentNodeP("stdcall", p))
+  elif pfNoConv in p.options.flags:
+    addSon(result, newIdentNodeP("noconv", p))
 
 proc addPragmas(father, pragmas: PNode) =
   if sonsLen(pragmas) > 0: addSon(father, pragmas)

--- a/cparse.nim
+++ b/cparse.nim
@@ -796,7 +796,10 @@ proc parseStructBody(p: var Parser, stmtList: PNode, isUnion: bool,
     elif p.tok.xkind == pxDirective or p.tok.xkind == pxDirectiveParLe:
       var define = parseDir(p, statement)
       addSon(result, define)
-      baseTyp = typeAtom(p)
+      if p.tok.xkind == pxSymbol:
+        baseTyp = typeAtom(p)
+      else:
+        continue
     else:
       baseTyp = typeAtom(p)
 

--- a/testsuite/results/struct_directives.nim
+++ b/testsuite/results/struct_directives.nim
@@ -1,0 +1,7 @@
+type
+  test* {.bycopy.} = object
+    when defined(A):
+      var a*: cint
+    when defined(B):
+      var b*: cint
+

--- a/testsuite/tests/struct_directives.h
+++ b/testsuite/tests/struct_directives.h
@@ -1,0 +1,8 @@
+struct test {
+#ifdef A
+  int a;
+#endif
+#ifdef B
+  int b;
+#endif
+};


### PR DESCRIPTION
When converting function types in .h, `{.noconv.}` can be added by this
options.

For example. Below is a C header file:

```C
// this declaration should be annotated with "noconv"
typedef int (*f_callback_funtion)(void *data, void *user_data);

// this is a function defined in C source
void register_callback(f_callback_funtion f, void *user_data);
```

If we want to define our callback function in nim, we can do it like this:

```nim
proc my_fun(data: pointer, user_data: pointer): cint {.exportc noconv.} = ...
register_callback(my_fun, nil)
```

