### PR TITLE
Implement deleted constructors (c++11)

### DIFF
--- a/cparse.nim
+++ b/cparse.nim
@@ -2245,8 +2245,13 @@ proc parseConstructor(p: var Parser, pragmas: PNode, isDestructor: bool;
     if p.tok.s == "default":
       eat(p, pxSymbol)
       eat(p, pxSemicolon)
+    elif p.tok.s == "delete":
+      # Deleted constructors should just be ignored.
+      eat(p, pxSymbol)
+      eat(p, pxSemicolon)
+      return emptyNode
     else:
-      parMessage(p, errGenerated, "expected 'default'")
+      parMessage(p, errGenerated, "expected 'default' or 'delete'")
   else:
     parMessage(p, errGenerated, "expected ';'")
   if result.sons[bodyPos].kind == nkEmpty:

--- a/cparse.nim
+++ b/cparse.nim
@@ -2308,10 +2308,15 @@ proc parseMethod(p: var Parser, origName: string, rettyp, pragmas: PNode,
     if pfKeepBodies in p.options.flags:
       result.sons[bodyPos] = body
   of pxAsgn:
-    # '= 0' aka abstract method:
     getTok(p)
-    eat(p, pxIntLit)
-    eat(p, pxSemicolon)
+    if p.tok.s == "delete":
+      eat(p, pxSymbol)
+      eat(p, pxSemiColon)
+      return emptyNode
+    else:
+      # '= 0' aka abstract method:
+      eat(p, pxIntLit)
+      eat(p, pxSemicolon)
   else:
     parMessage(p, errGenerated, "expected ';'")
   if result.sons[bodyPos].kind == nkEmpty:

--- a/cparse.nim
+++ b/cparse.nim
@@ -2250,6 +2250,9 @@ proc parseConstructor(p: var Parser, pragmas: PNode, isDestructor: bool;
       eat(p, pxSymbol)
       eat(p, pxSemicolon)
       return emptyNode
+    elif p.tok.xkind == pxIntLit:
+      eat(p, pxIntLit)
+      eat(p, pxSemicolon)
     else:
       parMessage(p, errGenerated, "expected 'default' or 'delete'")
   else:

--- a/testsuite/results/cpp11.nim
+++ b/testsuite/results/cpp11.nim
@@ -27,3 +27,17 @@ proc constructNonCopy*(): NonCopy {.constructor, importcpp: "NonCopy(@)",
                                  header: "cpp11.hpp".}
 proc destroyNonCopy*(this: var NonCopy) {.importcpp: "#.~NonCopy()",
                                       header: "cpp11.hpp".}
+type
+  VirtClass* {.importcpp: "VirtClass", header: "cpp11.hpp", bycopy.} = object
+
+
+proc constructVirtClass*(): VirtClass {.constructor, importcpp: "VirtClass(@)",
+                                     header: "cpp11.hpp".}
+proc destroyVirtClass*(this: var VirtClass) {.importcpp: "#.~VirtClass()",
+    header: "cpp11.hpp".}
+proc pureFunction*(this: var VirtClass) {.importcpp: "pureFunction",
+                                      header: "cpp11.hpp".}
+proc implementedFunction*(this: var VirtClass) {.importcpp: "implementedFunction",
+    header: "cpp11.hpp".}
+proc concreteFunction*(this: var VirtClass) {.importcpp: "concreteFunction",
+    header: "cpp11.hpp".}

--- a/testsuite/results/cpp11.nim
+++ b/testsuite/results/cpp11.nim
@@ -18,3 +18,12 @@ proc constructConstexprConstructor*(i: cint = 1): ConstexprConstructor {.constru
 ##  list initialization, issue #163
 
 var list_init* {.importcpp: "list_init", header: "cpp11.hpp".}: cint
+
+type
+  NonCopy* {.importcpp: "NonCopy", header: "cpp11.hpp", bycopy.} = object
+
+
+proc constructNonCopy*(): NonCopy {.constructor, importcpp: "NonCopy(@)",
+                                 header: "cpp11.hpp".}
+proc destroyNonCopy*(this: var NonCopy) {.importcpp: "#.~NonCopy()",
+                                      header: "cpp11.hpp".}

--- a/testsuite/tests/cpp11.hpp
+++ b/testsuite/tests/cpp11.hpp
@@ -14,3 +14,11 @@ class ConstexprConstructor {
 };
 // list initialization, issue #163
 constexpr int list_init{123};
+
+class NonCopy {
+public:
+  NonCopy() {}
+  ~NonCopy() {}
+  // deleted constructor, issue #165
+  NonCopy(const NonCopy &) = delete;
+};

--- a/testsuite/tests/cpp11.hpp
+++ b/testsuite/tests/cpp11.hpp
@@ -23,3 +23,12 @@ public:
   NonCopy(const NonCopy &) = delete;
   NonCopy &operator=(const NonCopy &) = delete;
 };
+
+class VirtClass {
+public:
+  VirtClass() = default;
+  ~VirtClass() = 0;
+  virtual void pureFunction() = 0;
+  virtual void implementedFunction();
+  void concreteFunction();
+};

--- a/testsuite/tests/cpp11.hpp
+++ b/testsuite/tests/cpp11.hpp
@@ -21,4 +21,5 @@ public:
   ~NonCopy() {}
   // deleted constructor, issue #165
   NonCopy(const NonCopy &) = delete;
+  NonCopy &operator=(const NonCopy &) = delete;
 };


### PR DESCRIPTION
This should fix  #165 by ignoring constructors with ` = delete;`