### PR TITLE
allow #define X after #ifndef X.

### DIFF
--- a/cpp.nim
+++ b/cpp.nim
@@ -256,8 +256,11 @@ proc isIncludeGuard(p: var Parser): bool =
   if p.tok.xkind == pxDirective and p.tok.s == "define":
     getTok(p) # skip #define
     expectIdent(p)
-    result = p.tok.s == guard
-    skipLine(p)
+    if p.tok.s == guard:
+      getTok(p)
+      if p.tok.xkind in {pxLineComment, pxNewLine, pxEof}:
+        result = true
+        skipLine(p)
 
 proc parseIfndef(p: var Parser; sectionParser: SectionParser): PNode =
   result = emptyNode

--- a/testsuite/results/directives.nim
+++ b/testsuite/results/directives.nim
@@ -1,0 +1,9 @@
+when not defined(ONE):
+  const
+    ONE* = (1)
+when not defined(TWO):
+  const
+    TWO* = (ONE + ONE)
+when not defined(THREE):
+  const
+    THREE* = "THREEEEE"

--- a/testsuite/tests/directives.h
+++ b/testsuite/tests/directives.h
@@ -1,0 +1,21 @@
+#ifndef DIRECTIvES_H
+#define DIRECTIvES_H
+
+#ifndef MY_SYMBOLS
+#define MY_SYMBOLS
+#endif
+
+#ifndef ONE
+#define ONE (1)
+#endif
+
+#ifndef TWO
+#define TWO (ONE + ONE)
+#endif
+
+#ifndef THREE
+#define THREE   "THREEEEE"
+#endif
+
+#endif
+


### PR DESCRIPTION
Below is a common pattern to create default values/configurations. It will be good to be recognized by `c2nim`.

```C
#ifndef ONE
#define ONE (1)
#endif
```

A test case is included in this PR.
