### PR TITLE
Hopefully avoid crlf in the repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text eol=lf
+* text=auto eol=lf


### PR DESCRIPTION
Users can still configure their own git clones to use crlf locally if they want.

* https://stackoverflow.com/questions/9976986/force-lf-eol-in-git-repo-and-working-copy