### PR TITLE
added --importc option

### DIFF
--- a/c2nim.nim
+++ b/c2nim.nim
@@ -32,6 +32,7 @@ Options:
   --cdecl                annotate procs with ``{.cdecl.}``
   --noconv               annotate procs with ``{.noconv.}``
   --stdcall              annotate procs with ``{.stdcall.}``
+  --importc              annotate procs with ``{.importc.}``
   --ref                  convert typ* to ref typ (default: ptr typ)
   --prefix:PREFIX        strip prefix for the generated Nim identifiers
                          (multiple --prefix options are supported)

--- a/cparse.nim
+++ b/cparse.nim
@@ -33,6 +33,7 @@ type
     pfRefs,             ## use "ref" instead of "ptr" for C's typ*
     pfCDecl,            ## annotate procs with cdecl
     pfStdCall,          ## annotate procs with stdcall
+    pfImportc,          ## annotate procs with importc
     pfNoConv,           ## annotate procs with noconv
     pfSkipInclude,      ## skip all ``#include``
     pfTypePrefixes,     ## all generated types start with 'T' or 'P'
@@ -129,6 +130,7 @@ proc setOption*(parserOptions: PParserOptions, key: string, val=""): bool =
     if val.len > 0: parserOptions.headerOverride = val
   of "cdecl": incl(parserOptions.flags, pfCdecl)
   of "stdcall": incl(parserOptions.flags, pfStdCall)
+  of "importc": incl(parserOptions.flags, pfImportc)
   of "noconv": incl(parserOptions.flags, pfNoConv)
   of "prefix": parserOptions.prefixes.add(val)
   of "suffix": parserOptions.suffixes.add(val)
@@ -1437,6 +1439,8 @@ proc declaration(p: var Parser; genericParams: PNode = emptyNode): PNode =
       addSon(pragmas, newIdentNodeP("cdecl", p))
     elif pfStdcall in p.options.flags:
       addSon(pragmas, newIdentNodeP("stdcall", p))
+    if pfImportc in p.options.flags:
+      addSon(pragmas, newIdentStrLitPair(p.options.importcLit, origName, p))
     # no pattern, no exceptions:
     addSon(result, exportSym(p, name, origName), emptyNode, genericParams)
     addSon(result, params, pragmas, emptyNode) # no exceptions

--- a/rules.nim
+++ b/rules.nim
@@ -98,7 +98,10 @@ proc getHeaderPair(p: Parser): PNode =
     newIdentStrLitPair("header", p.header, p)
 
 proc addImportToPragma(pragmas: PNode, ident: string, p: Parser) =
-  addSon(pragmas, newIdentStrLitPair(p.options.importcLit, ident, p))
+  if pfImportc in p.options.flags:
+    discard # already added importc pragma
+  else:
+    addSon(pragmas, newIdentStrLitPair(p.options.importcLit, ident, p))
   if p.options.dynlibSym.len > 0:
     addSon(pragmas, newIdentPair("dynlib", p.options.dynlibSym, p))
   else:


### PR DESCRIPTION
Added a command line option to annotate procs with `{.importc:"<origName>".}`

The `--header` command line option adds `importc` and `header` pragmas to types as well as procs, but I only want `importc` pragmas on the procs.