### PR TITLE
fix warning about deprecated union pragmas

### DIFF
--- a/cparse.nim
+++ b/cparse.nim
@@ -93,8 +93,8 @@ type
 
 proc parseDir(p: var Parser; sectionParser: SectionParser): PNode
 proc addTypeDef(section, name, t, genericParams: PNode)
-proc parseStruct(p: var Parser, stmtList: PNode, isUnion: bool): PNode
-proc parseStructBody(p: var Parser, stmtList: PNode, isUnion: bool,
+proc parseStruct(p: var Parser, stmtList: PNode): PNode
+proc parseStructBody(p: var Parser, stmtList: PNode,
                      kind: TNodeKind = nkRecList): PNode
 
 proc newParserOptions*(): PParserOptions =
@@ -721,7 +721,8 @@ proc parseField(p: var Parser, kind: TNodeKind): PNode =
     else: result = mangledIdent(p.tok.s, p, skField)
     getTok(p, result)
 
-proc structPragmas(p: Parser, name: PNode, origName: string): PNode =
+proc structPragmas(p: Parser, name: PNode, origName: string,
+                   isUnion: bool): PNode =
   assert name.kind == nkIdent
   result = newNodeP(nkPragmaExpr, p)
   addSon(result, exportSym(p, name, origName))
@@ -735,6 +736,7 @@ proc structPragmas(p: Parser, name: PNode, origName: string): PNode =
     addSon(pragmas, newIdentNodeP("inheritable", p))
     addSon(pragmas, newIdentNodeP("pure", p))
   pragmas.add newIdentNodeP("bycopy", p)
+  if isUnion: pragmas.add newIdentNodeP("union", p)
   result.add pragmas
 
 proc hashPosition(p: Parser): string =
@@ -758,22 +760,18 @@ proc parseInnerStruct(p: var Parser, stmtList: PNode,
     structName = name & "_" & p.hashPosition
   let typeSection = newNodeP(nkTypeSection, p)
   let newStruct = newNodeP(nkObjectTy, p)
-  var pragmas = emptyNode
-  if isUnion:
-    pragmas = newNodeP(nkPragma, p)
-    addSon(pragmas, newIdentNodeP("union", p))
-  addSon(newStruct, pragmas, emptyNode) # no inheritance
+  addSon(newStruct, emptyNode, emptyNode) # no pragmas, no inheritance
   result = newNodeP(nkIdent, p)
   result.ident = getIdent(structName)
-  let struct = parseStructBody(p, stmtList, isUnion)
+  let struct = parseStructBody(p, stmtList)
   let defName = newNodeP(nkIdent, p)
   defName.ident = getIdent(structName)
   addSon(newStruct, struct)
-  addTypeDef(typeSection, structPragmas(p, defName, "no_name"), newStruct,
-             emptyNode)
+  addTypeDef(typeSection, structPragmas(p, defName, "no_name", isUnion),
+             newStruct, emptyNode)
   addSon(stmtList, typeSection)
 
-proc parseStructBody(p: var Parser, stmtList: PNode, isUnion: bool,
+proc parseStructBody(p: var Parser, stmtList: PNode,
                      kind: TNodeKind = nkRecList): PNode =
   result = newNodeP(kind, p)
   eat(p, pxCurlyLe, result)
@@ -887,16 +885,13 @@ proc parseInheritance(p: var Parser; result: PNode) =
         discard typeAtom(p)
     result.sons[0] = inh
 
-proc parseStruct(p: var Parser, stmtList: PNode, isUnion: bool): PNode =
+proc parseStruct(p: var Parser, stmtList: PNode): PNode =
   result = newNodeP(nkObjectTy, p)
   var pragmas = emptyNode
-  if isUnion:
-    pragmas = newNodeP(nkPragma, p)
-    addSon(pragmas, newIdentNodeP("union", p))
   addSon(result, pragmas, emptyNode) # no inheritance
   parseInheritance(p, result)
   if p.tok.xkind == pxCurlyLe:
-    addSon(result, parseStructBody(p, stmtList, isUnion))
+    addSon(result, parseStructBody(p, stmtList))
   else:
     addSon(result, newNodeP(nkRecList, p))
 
@@ -1137,17 +1132,16 @@ proc enumFields(p: var Parser, constList: PNode): PNode =
         else: parMessage(p, errGenerated, outofOrder)
     of isAlias:
       var constant = createConst(f.node.getEnumIdent, emptyNode, f.value, p)
-      constList.addSon(constant)
 
 
 proc parseTypedefStruct(p: var Parser, result, stmtList: PNode, isUnion: bool) =
   getTok(p, result)
   if p.tok.xkind == pxCurlyLe:
-    var t = parseStruct(p, stmtList, isUnion)
+    var t = parseStruct(p, stmtList)
     var origName = p.tok.s
     markTypeIdent(p, nil)
     var name = skipIdent(p, skType)
-    addTypeDef(result, structPragmas(p, name, origName), t, emptyNode)
+    addTypeDef(result, structPragmas(p, name, origName, isUnion), t, emptyNode)
     parseTrailingDefinedTypes(p, result, name)
   elif p.tok.xkind == pxSymbol:
     # name to be defined or type "struct a", we don't know yet:
@@ -1156,17 +1150,17 @@ proc parseTypedefStruct(p: var Parser, result, stmtList: PNode, isUnion: bool) =
     var nameOrType = skipIdent(p, skVar)
     case p.tok.xkind
     of pxCurlyLe:
-      var t = parseStruct(p, stmtList, isUnion)
+      var t = parseStruct(p, stmtList)
       if p.tok.xkind == pxSymbol:
         # typedef struct tagABC {} abc, *pabc;
         # --> abc is a better type name than tagABC!
         markTypeIdent(p, nil)
         var origName = p.tok.s
         var name = skipIdent(p, skType)
-        addTypeDef(result, structPragmas(p, name, origName), t, emptyNode)
+        addTypeDef(result, structPragmas(p, name, origName, isUnion), t, emptyNode)
         parseTrailingDefinedTypes(p, result, name)
       else:
-        addTypeDef(result, structPragmas(p, nameOrType, origName), t,
+        addTypeDef(result, structPragmas(p, nameOrType, origName, isUnion), t,
                    emptyNode)
     of pxSymbol:
       # typedef struct a a?
@@ -2025,8 +2019,8 @@ proc declarationOrStatement(p: var Parser): PNode =
       result = expressionStatement(p)
   assert result != nil
 
-proc parseTuple(p: var Parser, statements: PNode, isUnion: bool): PNode =
-  parseStructBody(p, statements, isUnion, nkTupleTy)
+proc parseTuple(p: var Parser, statements: PNode): PNode =
+  parseStructBody(p, statements, nkTupleTy)
 
 proc parseTrailingDefinedIdents(p: var Parser, result, baseTyp: PNode) =
   var varSection = newNodeP(nkVarSection, p)
@@ -2058,13 +2052,14 @@ proc parseStandaloneStruct(p: var Parser, isUnion: bool;
   if p.tok.xkind in {pxCurlyLe, pxSemiColon, pxColon}:
     if origName.len > 0:
       var name = mangledIdent(origName, p, skType)
-      var t = parseStruct(p, result, isUnion)
+      var t = parseStruct(p, result)
       var typeSection = newNodeP(nkTypeSection, p)
-      addTypeDef(typeSection, structPragmas(p, name, origName), t, genericParams)
+      addTypeDef(typeSection, structPragmas(p, name, origName, isUnion), t,
+                 genericParams)
       addSon(result, typeSection)
       parseTrailingDefinedIdents(p, result, name)
     else:
-      var t = parseTuple(p, result, isUnion)
+      var t = parseTuple(p, result)
       parseTrailingDefinedIdents(p, result, t)
   else:
     backtrackContext(p)
@@ -2593,11 +2588,11 @@ proc parseStandaloneClass(p: var Parser, isStruct: bool;
         p.currentClassOrig = oldClassOrig
         p.options.classes[p.currentClassOrig] = "true"
         return result
-      addTypeDef(typeSection, structPragmas(p, name, p.currentClassOrig), t,
+      addTypeDef(typeSection, structPragmas(p, name, p.currentClassOrig, false), t,
                  genericParams)
       parseTrailingDefinedIdents(p, result, name)
     else:
-      var t = parseTuple(p, result, isUnion=false)
+      var t = parseTuple(p, result)
       parseTrailingDefinedIdents(p, result, t)
   else:
     backtrackContext(p)


### PR DESCRIPTION
When compiling union definitions generated by c2nim the compiler outputs the warning

```
Warning: type pragmas follow the type name; this form of writing pragmas is deprecated [Deprecated]
```

It's because the ``{.union.}`` pragma is added after the ``object`` keyword, e.g.

```
type MyUnion* {.bycopy.} = object {.union.}
  value_one: int
  value_two: float
```

This PR fixes it by inserting the pragma after the type name instead, e.g.

```
type MyUnion* {.bycopy, union.} = object
  value_one: int
  value_two: float
```

The ``isUnion`` argument is removed in procs that no longer need it. This includes ``proc parseTuple`` where it did not have any effect anyway.