### PR TITLE
export constants that are generated from enum aliases

### DIFF
--- a/cparse.nim
+++ b/cparse.nim
@@ -1136,7 +1136,9 @@ proc enumFields(p: var Parser, constList: PNode): PNode =
         of nkIdent: lastIdent = f.node
         else: parMessage(p, errGenerated, outofOrder)
     of isAlias:
-      var constant = createConst(f.node.getEnumIdent, emptyNode, f.value, p)
+      let ident = f.node.getEnumIdent
+      var constant = createConst(exportSym(p, ident, ident.ident.s), emptyNode,
+                                 f.value, p)
       constList.addSon(constant)
 
 


### PR DESCRIPTION
If a C enum contains an alias, c2nim generates a constant, e.g.

```
typedef enum {
  one = 1,
  two = 2,
  another_two = two,
  three = 3
} my_enum;
```

becomes

```
type
  my_enum* = enum
    one = 1, two = 2, three = 3

const
  another_two = two
```

Unfortunately that constant is not exported from the module. This PR fixes that.