### PR TITLE
fix parsing casted int64 constants

### DIFF
--- a/clex.nim
+++ b/clex.nim
@@ -375,7 +375,7 @@ proc getNumber(L: var Lexer, tok: var Token) =
       tok.fnumber = parseFloat(tok.s)
       tok.xkind = pxFloatLit
     else:
-      tok.iNumber = parseInt(tok.s)
+      tok.iNumber = parseBiggestInt(tok.s)
       if (tok.iNumber < low(int32)) or (tok.iNumber > high(int32)):
         tok.xkind = pxInt64Lit
       else:

--- a/cparse.nim
+++ b/cparse.nim
@@ -1630,7 +1630,7 @@ proc startExpression(p: var Parser, tok: Token): PNode =
       if p.tok.xkind != pxParRi:
         raise newException(ERetryParsing, "expected a ')'")
       getTok(p, result)
-      if p.tok.xkind in {pxSymbol, pxIntLit, pxFloatLit, pxStrLit, pxCharLit}:
+      if p.tok.xkind in {pxSymbol, pxIntLit, pxInt64Lit, pxFloatLit, pxStrLit, pxCharLit}:
         raise newException(ERetryParsing, "expected a non literal token")
       closeContext(p)
     except ERetryParsing:


### PR DESCRIPTION
Parsing casted int64 constants greater than ``2^31 - 1`` does not work.

E.g. parsing the code
``` C
#define MY_MACRO ((uint64_t)2147483648)
```

will fail with this error message
```
Error: identifier expected, but got: (
```

This PR fixes that. It also calls ``parseBiggestInt`` instead of ``parseInt``. This should avoid problems on 32-bit architectures (not tested).