### PR TITLE
small improvements in proc parseStandaloneClass

### DIFF
--- a/cparse.nim
+++ b/cparse.nim
@@ -2576,7 +2576,7 @@ proc parseStandaloneClass(p: var Parser, isStruct: bool;
   saveContext(p)
   getTok(p, result) # skip "class" or "struct"
   let oldClass = p.currentClass
-  var oldClassOrig = p.currentClassOrig
+  let oldClassOrig = p.currentClassOrig
   p.currentClassOrig = ""
   if p.tok.xkind == pxSymbol:
     markTypeIdent(p, nil)
@@ -2599,8 +2599,7 @@ proc parseStandaloneClass(p: var Parser, isStruct: bool;
         result.add(newStrNodeP(nkStrLit, "forward decl of " & p.currentClassOrig, p))
         p.currentClass = oldClass
         p.currentClassOrig = oldClassOrig
-        p.options.classes[p.currentClassOrig] = "true"
-        return result
+        return
       addTypeDef(typeSection, structPragmas(p, name, p.currentClassOrig, false), t,
                  genericParams)
       parseTrailingDefinedIdents(p, result, name)

--- a/cparse.nim
+++ b/cparse.nim
@@ -2576,7 +2576,7 @@ proc parseStandaloneClass(p: var Parser, isStruct: bool;
   saveContext(p)
   getTok(p, result) # skip "class" or "struct"
   let oldClass = p.currentClass
-  let oldClassOrig = p.currentClassOrig
+  var oldClassOrig = p.currentClassOrig
   p.currentClassOrig = ""
   if p.tok.xkind == pxSymbol:
     markTypeIdent(p, nil)


### PR DESCRIPTION
- oldClassOrig can be immutable
- line not needed: ``p.options.classes[p.currentClassOrig] = "true"``