### PR TITLE
Add `#mangle` example for fixing C identifiers (to conform nep1-style)

### DIFF
--- a/doc/c2nim.rst
+++ b/doc/c2nim.rst
@@ -244,6 +244,8 @@ too, there is no need to quote them:
   #mangle ssize_t  int
   // is short for:
   #mangle "'ssize_t'" "int"
+  
+To fix leading/trailing/underscore identifiers in C code use `#mangle "^'_'*{@}('_'*$)" "$1"`
 
 ``#assumedef`` and ``#assumendef`` directives
 ----------------------------------------------


### PR DESCRIPTION
Given

```c
void foo() {}
void foo_() {}
void foo__() {}
void __foo() {}
void __foo__() {}
void foo_bar_() {}
void foo_bar() {}
void _foo_bar_() {}
void foo() {}
void foo_() {}
void foo__() {}
void __foo() {}
void __foo__() {}
void foo_bar_() {}
void foo_bar() {}
void _foo_bar_() {}
void _____foo___var_asdfasdf_asdf_asdfa_() {}
void ______________asss____() {}
void ____s_____() {}
```

outputs 

```nim
proc foo*() =
  discard

proc foo*() =
  discard

proc foo*() =
  discard

proc foo*() =
  discard

proc foo*() =
  discard

proc foo_bar*() =
  discard

proc foo_bar*() =
  discard

proc foo_bar*() =
  discard

proc foo*() =
  discard

proc foo*() =
  discard

proc foo*() =
  discard

proc foo*() =
  discard

proc foo*() =
  discard

proc foo_bar*() =
  discard

proc foo_bar*() =
  discard

proc foo_bar*() =
  discard

proc foo___var_asdfasdf_asdf_asdfa*() =
  discard

proc asss*() =
  discard

proc s*() =
  discard
```
which seems to be what most users would want