### PR TITLE
Add varargs to defines, defines as C imports, and CLI mangle option

### DIFF
--- a/c2nim.nim
+++ b/c2nim.nim
@@ -48,6 +48,10 @@ Options:
                          (multiple --prefix options are supported)
   --suffix:SUFFIX        strip suffix for the generated Nim identifiers
                          (multiple --suffix options are supported)
+  --mangle:PEG=FORMAT    extra PEG expression to mangle identifiers,
+                         for example `--mangle:'{u?}int{\d+}_t=$1int$2'` to
+                         convert C <stdint.h> to Nim equivalents
+                         (multiple --mangle options are supported)
   --paramprefix:PREFIX   add prefix to parameter name of the generated Nim proc
   --assumedef:IDENT      skips #ifndef sections for the given C identifier
                          (multiple --assumedef options are supported)

--- a/c2nim.nim
+++ b/c2nim.nim
@@ -41,6 +41,8 @@ Options:
   --noconv               annotate procs with ``{.noconv.}``
   --stdcall              annotate procs with ``{.stdcall.}``
   --importc              annotate procs with ``{.importc.}``
+  --importdefines        import C defines as procs or vars with ``{.importc.}``
+  --importfuncdefines    import C define funcs as procs with ``{.importc.}``
   --ref                  convert typ* to ref typ (default: ptr typ)
   --prefix:PREFIX        strip prefix for the generated Nim identifiers
                          (multiple --prefix options are supported)

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -1168,7 +1168,13 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
     else:
       put(g, tkPtr, "ptr")
   of nkVarTy:
-    if sonsLen(n) > 0:
+    if sonsLen(n) > 2 and n.sons[1].kind == nkPragma:
+      putWithSpace(g, tkVar, "var")
+      gsub(g, n.sons[0])
+      gsub(g, n.sons[1])
+      putWithSpace(g, tkColon, ":")
+      gsub(g, n.sons[2])
+    elif sonsLen(n) > 0:
       putWithSpace(g, tkVar, "var")
       gsub(g, n.sons[0])
     else:
@@ -1188,14 +1194,9 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
   of nkTypeDef:
     if n.sons[0].kind == nkPragmaExpr:
       # generate pragma after generic
-      echo "generate pragma after generic, n.len: ", $n.len
-      echo "g.p0: ", $g.buf
       gsub(g, n.sons[0], 0)
-      echo "g.p1: ", $g.buf
       gsub(g, n, 1)
-      echo "g.p2: ", $g.buf
       gsub(g, n.sons[0], 1)
-      echo "g.pre: ", $g.buf
     else:
       gsub(g, n, 0)
       gsub(g, n, 1)

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -1188,9 +1188,14 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
   of nkTypeDef:
     if n.sons[0].kind == nkPragmaExpr:
       # generate pragma after generic
+      echo "generate pragma after generic, n.len: ", $n.len
+      echo "g.p0: ", $g.buf
       gsub(g, n.sons[0], 0)
+      echo "g.p1: ", $g.buf
       gsub(g, n, 1)
+      echo "g.p2: ", $g.buf
       gsub(g, n.sons[0], 1)
+      echo "g.pre: ", $g.buf
     else:
       gsub(g, n, 0)
       gsub(g, n, 1)

--- a/cparser.nim
+++ b/cparser.nim
@@ -66,7 +66,7 @@ type
     toPreprocess: StringTableRef
     inheritable: StringTableRef
     debugMode, followNep1: bool
-    useHeader, importdefines: bool
+    useHeader, importdefines, importfuncdefines: bool
     discardablePrefixes: seq[string]
     constructor, destructor, importcLit: string
     exportPrefix*: string
@@ -150,6 +150,8 @@ proc setOption*(parserOptions: PParserOptions, key: string, val=""): bool =
   of "header":
     parserOptions.useHeader = true
     if val.len > 0: parserOptions.headerOverride = val
+  of "importfuncdefines":
+    parserOptions.importfuncdefines = true
   of "importdefines":
     parserOptions.importdefines = true
   of "cdecl": incl(parserOptions.flags, pfCdecl)

--- a/cparser.nim
+++ b/cparser.nim
@@ -66,7 +66,7 @@ type
     toPreprocess: StringTableRef
     inheritable: StringTableRef
     debugMode, followNep1: bool
-    useHeader, definesAsDecls: bool
+    useHeader, importdefines: bool
     discardablePrefixes: seq[string]
     constructor, destructor, importcLit: string
     exportPrefix*: string
@@ -150,8 +150,8 @@ proc setOption*(parserOptions: PParserOptions, key: string, val=""): bool =
   of "header":
     parserOptions.useHeader = true
     if val.len > 0: parserOptions.headerOverride = val
-  of "definesasdecls":
-    parserOptions.definesAsDecls = true
+  of "importdefines":
+    parserOptions.importdefines = true
   of "cdecl": incl(parserOptions.flags, pfCdecl)
   of "stdcall": incl(parserOptions.flags, pfStdCall)
   of "importc": incl(parserOptions.flags, pfImportc)

--- a/cparser.nim
+++ b/cparser.nim
@@ -164,6 +164,9 @@ proc setOption*(parserOptions: PParserOptions, key: string, val=""): bool =
     if val.len > 0: parserOptions.paramPrefix = val
   of "assumedef": parserOptions.assumeDef.add(val)
   of "assumendef": parserOptions.assumenDef.add(val)
+  of "mangle":
+    let vals = val.split("=")
+    parserOptions.mangleRules.add((parsePeg(vals[0]), vals[1]))
   of "skipinclude": incl(parserOptions.flags, pfSkipInclude)
   of "typeprefixes": incl(parserOptions.flags, pfTypePrefixes)
   of "skipcomments": incl(parserOptions.flags, pfSkipComments)

--- a/cparser.nim
+++ b/cparser.nim
@@ -65,7 +65,8 @@ type
     classes: StringTableRef
     toPreprocess: StringTableRef
     inheritable: StringTableRef
-    debugMode, followNep1, useHeader: bool
+    debugMode, followNep1: bool
+    useHeader, definesAsDecls: bool
     discardablePrefixes: seq[string]
     constructor, destructor, importcLit: string
     exportPrefix*: string
@@ -149,6 +150,8 @@ proc setOption*(parserOptions: PParserOptions, key: string, val=""): bool =
   of "header":
     parserOptions.useHeader = true
     if val.len > 0: parserOptions.headerOverride = val
+  of "definesasdecls":
+    parserOptions.definesAsDecls = true
   of "cdecl": incl(parserOptions.flags, pfCdecl)
   of "stdcall": incl(parserOptions.flags, pfStdCall)
   of "importc": incl(parserOptions.flags, pfImportc)

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,1 +1,8 @@
 -d:nimOldCaseObjects
+-d:debug
+--debugger:native
+--lineDir:on
+--debuginfo:on
+# --stacktrace:off
+--passC:"-Og"
+--opt:none

--- a/preprocessor.nim
+++ b/preprocessor.nim
@@ -149,31 +149,27 @@ proc parseDefineAsDecls(p: var Parser; hasParams: bool): PNode =
     addSon(result, pragmas) 
     addSon(result, emptyNode)
 
-    skipLine(p)
     addSon(result, emptyNode)
+    skipLine(p)
 
   else:
     # a macro without parameters:
-    result = newNodeP(nkTypeDef, p)
-    var pe = newNodeP(nkPragmaExpr, p)
-    var pragmas = newNodeP(nkPragma, p)
+    result = newNodeP(nkVarTy, p)
 
     while true:
-      var vdef = newNodeP(nkVarTy, p)
-      addSon(vdef, skipIdentExport(p, skConst))
-      skipStarCom(p, vdef)
-
+      let vname = skipIdentExport(p, skConst)
+      # skipStarCom(p, result)
       let iname = cppImportName(p, origName)
-      addSon(pragmas, newIdentStrLitPair(p.options.importcLit, iname, p))
-      addSon(pragmas, getHeaderPair(p))
+      var vpragmas = newNodeP(nkPragma, p)
+      addSon(vpragmas, newIdentStrLitPair(p.options.importcLit, iname, p))
+      addSon(vpragmas, getHeaderPair(p))
+      let vtype = newIdentNodeP("int", p)
 
+      addSon(result, vname)
+      addSon(result, vpragmas)
+      addSon(result, vtype)
 
-      addSon(pe, vdef)
-      addSon(pe, newIdentNodeP("int", p))
-      addSon(result, pe)
-      # addSon(result, emptyNode)
-      result.add(pragmas)
-
+      skipCom(p, result)
       skipLine(p) # eat the rest of the define, skip parsing
       if p.tok.xkind == pxDirective and p.tok.s == "define":
         getTok(p)

--- a/preprocessor.nim
+++ b/preprocessor.nim
@@ -154,21 +154,25 @@ proc parseDefineAsDecls(p: var Parser; hasParams: bool): PNode =
 
   else:
     # a macro without parameters:
-    result = newNodeP(nkExprColonExpr, p)
+    result = newNodeP(nkTypeDef, p)
+    var pe = newNodeP(nkPragmaExpr, p)
     var pragmas = newNodeP(nkPragma, p)
 
     while true:
-      var vdef = newNodeP(nkVarSection, p)
-      addSon(vdef , skipIdentExport(p, skConst))
+      var vdef = newNodeP(nkVarTy, p)
+      addSon(vdef, skipIdentExport(p, skConst))
+      skipStarCom(p, vdef)
 
       let iname = cppImportName(p, origName)
       addSon(pragmas, newIdentStrLitPair(p.options.importcLit, iname, p))
       addSon(pragmas, getHeaderPair(p))
-      addSon(vdef, pragmas)
 
-      skipStarCom(p, vdef)
-      addSon(result, vdef)
-      addSon(result, newIdentNodeP("int", p))
+
+      addSon(pe, vdef)
+      addSon(pe, newIdentNodeP("int", p))
+      addSon(result, pe)
+      # addSon(result, emptyNode)
+      result.add(pragmas)
 
       skipLine(p) # eat the rest of the define, skip parsing
       if p.tok.xkind == pxDirective and p.tok.s == "define":

--- a/preprocessor.nim
+++ b/preprocessor.nim
@@ -154,32 +154,23 @@ proc parseDefineAsDecls(p: var Parser; hasParams: bool): PNode =
 
   else:
     # a macro without parameters:
-    # result = newNodeP(nkVarSection, p)
     result = newNodeP(nkExprColonExpr, p)
+    var pragmas = newNodeP(nkPragma, p)
 
     while true:
-      var origName = p.tok.s
-      # var varKind = nkVarSection
-      var c = newNodeP(nkVarSection, p)
-      # skipDeclarationSpecifiers(p, varKind)
-      # parseCallConv(p, pragmas)
-      addSon(c, skipIdentExport(p, skConst))
+      var vdef = newNodeP(nkVarSection, p)
+      addSon(vdef , skipIdentExport(p, skConst))
 
       let iname = cppImportName(p, origName)
-      var pragmas = newNodeP(nkPragma, p)
       addSon(pragmas, newIdentStrLitPair(p.options.importcLit, iname, p))
       addSon(pragmas, getHeaderPair(p))
-      addSon(c, pragmas)
+      addSon(vdef, pragmas)
 
-      skipStarCom(p, c)
-      addSon(result, c)
-      # var declt = newNodeP(nkExprColonExpr, p)
-      # addSon(declt, newIdentNodeP("untyped", p))
-      # addSon(c, declt)
+      skipStarCom(p, vdef)
+      addSon(result, vdef)
       addSon(result, newIdentNodeP("int", p))
 
-      skipLine(p)
-      # result = c
+      skipLine(p) # eat the rest of the define, skip parsing
       if p.tok.xkind == pxDirective and p.tok.s == "define":
         getTok(p)
       else:

--- a/preprocessor.nim
+++ b/preprocessor.nim
@@ -84,8 +84,6 @@ proc parseDefine(p: var Parser; hasParams: bool): PNode =
     addSon(result, emptyNode)
     var kind = parseDefineBody(p, result)
     params.sons[0] = newIdentNodeP(kind, p)
-    echo "parseDefine: kind: ", $kind
-    echo "parseDefine: params: ", $params.sons[0]
     eatNewLine(p, result)
   else:
     # a macro without parameters:
@@ -186,7 +184,6 @@ proc parseDef(p: var Parser, m: var Macro; hasParams: bool): bool =
   if hasParams:
     eat(p, pxParLe)
     while p.tok.xkind != pxParRi:
-      echo "parseDef: ", $p.tok.xkind
       if p.tok.xkind == pxDotDotDot:
         # addSon(pragmas, newIdentNodeP("varargs", p))
         getTok(p)


### PR DESCRIPTION
Hey! Thanks for keeping `c2nim` up and working! 

I decided to take the time to fix/tweak a few things that I run into a lot and figure others might find them useful. 

- Importing C `#defines` macro functions as external C functions using `importc` pragma
- Import C `#defines` constants as external C var's using `importc`
- Add VARARGS support for `#define` macro functions supporting templates 
  + Note this doesn't create a proper macro to handle the varargs but it creates filler `args: seq[untyped]` 
- Add VARARGS support for  `#define` macro functions supporting C imports with `{.varargs.}` pragma
- Add command line option to pass mangle directives (useful for all those `uint8_t` types from `<stdint.h>`) 

I'll work on adding the test cases I'm using tomorrow. I haven't run the test suite yet, but I'll do that tomorrow. However, I wanted to get this up so I wouldn't forget to PR it later. 

Also, any feedback/changes would be great. I tried to follow the coding style as much as I could. Still I'm not entirely familiar with the correct `PNode` structures for some of the items. Particularly if there's a "proper" way to handle some of the constructs. 


 