### PR TITLE
supports Arc/Orc by enabling deepcopy

### DIFF
--- a/c2nim.nimble
+++ b/c2nim.nimble
@@ -8,7 +8,7 @@ skipExt = @["nim"]
 
 bin = @["c2nim"]
 
-requires "nim >= 1.2.0"
+requires "nim >= 1.4.0"
 
 import strutils
 

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,1 +1,2 @@
 -d:nimOldCaseObjects
+--deepcopy:on


### PR DESCRIPTION
Bump minimal version requirements because deepcopy is only introduced since Nim 1.4.0

ref https://github.com/nim-lang/Nim/pull/19972