### PR TITLE
replace shallowCopy with move, otherwise it fails nimgen

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -187,11 +187,17 @@ proc setDirtyFile*(conf: ConfigRef; fileIdx: FileIndex; filename: AbsoluteFile) 
 
 proc setHash*(conf: ConfigRef; fileIdx: FileIndex; hash: string) =
   assert fileIdx.int32 >= 0
-  shallowCopy(conf.m.fileInfos[fileIdx.int32].hash, hash)
+  when defined(gcArc) or defined(gcOrc):
+    conf.m.fileInfos[fileIdx.int32].hash = hash
+  else:
+    shallowCopy(conf.m.fileInfos[fileIdx.int32].hash, hash)
 
 proc getHash*(conf: ConfigRef; fileIdx: FileIndex): string =
   assert fileIdx.int32 >= 0
-  shallowCopy(result, conf.m.fileInfos[fileIdx.int32].hash)
+  when defined(gcArc) or defined(gcOrc):
+    result = conf.m.fileInfos[fileIdx.int32].hash
+  else:
+    shallowCopy(result, conf.m.fileInfos[fileIdx.int32].hash)
 
 proc toFullPathConsiderDirty*(conf: ConfigRef; fileIdx: FileIndex): AbsoluteFile =
   if fileIdx.int32 < 0:


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/pull/19972

```
2022-07-28T11:12:09.4182108Z Downloading https://github.com/nim-lang/c2nim using git
2022-07-28T11:12:09.4182506Z   Verifying dependencies for c2nim@#head
2022-07-28T11:12:09.4182810Z  Installing c2nim@#head
2022-07-28T11:12:09.4183134Z    Building c2nim/c2nim using c backend
2022-07-28T11:12:09.4183913Z [1m/tmp/nimble_20270/githubcom_nimlangc2nim_#head/c2nim.nim(12, 16) [0m[33mWarning: [0mNumber of spaces around '/' is not consistent[36m [Spacing][0m[0m
2022-07-28T11:12:09.4184858Z [1m/tmp/nimble_20270/githubcom_nimlangc2nim_#head/compiler/llstream.nim(13, 3) [0m[33mWarning: [0mimported and not used: 'strutils'[36m [UnusedImport][0m[0m
2022-07-28T11:12:09.4186479Z [1m/tmp/nimble_20270/githubcom_nimlangc2nim_#head/compiler/options.nim(11, 26) [0m[33mWarning: [0mimported and not used: 'osproc'[36m [UnusedImport][0m[0m
2022-07-28T11:12:09.4187298Z [1m/tmp/nimble_20270/githubcom_nimlangc2nim_#head/compiler/idents.nim(15, 11) [0m[33mWarning: [0mimported and not used: 'strutils'[36m [UnusedImport][0m[0m
2022-07-28T11:12:09.4188112Z [1m/tmp/nimble_20270/githubcom_nimlangc2nim_#head/compiler/ast.nim(13, 41) [0m[33mWarning: [0mimported and not used: 'strutils'[36m [UnusedImport][0m[0m
2022-07-28T11:12:09.4188892Z [1m/tmp/nimble_20270/githubcom_nimlangc2nim_#head/compiler/ast.nim(13, 55) [0m[33mWarning: [0mimported and not used: 'sha1'[36m [UnusedImport][0m[0m
2022-07-28T11:12:09.4189688Z [1m/tmp/nimble_20270/githubcom_nimlangc2nim_#head/compiler/ast.nim(13, 22) [0m[33mWarning: [0mimported and not used: 'nversion'[36m [UnusedImport][0m[0m
2022-07-28T11:12:09.4190486Z [1m/tmp/nimble_20270/githubcom_nimlangc2nim_#head/compiler/ast.nim(13, 32) [0m[33mWarning: [0mimported and not used: 'options'[36m [UnusedImport][0m[0m
2022-07-28T11:12:09.4191223Z [1m/tmp/nimble_20270/githubcom_nimlangc2nim_#head/compiler/msgs.nim(190, 3) [0m[31mError: [0mundeclared identifier: 'shallowCopy'
2022-07-28T11:12:09.4191761Z candidates (edit distance, scope distance); see '--spellSuggest': 
2022-07-28T11:12:09.4192264Z  (4, 4): 'shallow' [proc declared in /home/runner/work/Nim/Nim/lib/system.nim(2799, 6)]
2022-07-28T11:12:09.4192788Z  (4, 4): 'shallow' [proc declared in /home/runner/work/Nim/Nim/lib/system.nim(2809, 6)][36m[0m[0m
2022-07-28T11:12:09.4193277Z        Tip: 9 messages have been suppressed, use --verbose to show them.
2022-07-28T11:12:09.4193601Z      Error: Build failed for package: c2nim
2022-07-28T11:12:09.4193897Z         ... Execution failed with exit code 1
2022-07-28T11:12:09.4194754Z         ... Command: /home/runner/work/Nim/Nim/bin/nim c --colors:on --noNimblePath -d:release -d:NimblePkgVersion=0.9.18 --hints:off -o:'/tmp/nimble_20270/githubcom_nimlangc2nim_#head/c2nim' '/tmp/nimble_20270/githubcom_nimlangc2nim_#head/c2nim.nim'
```