### PR TITLE
Better handling of CPP static methods

### DIFF
--- a/c2nim.nim
+++ b/c2nim.nim
@@ -72,6 +72,7 @@ Options:
   --mergeBlocks          merge similar adjacent blocks like two let sections
   --ignoreRValueRefs     translate C++'s ``T&&`` to ``T`` instead ``of var T``
   --keepBodies           keep C++'s method bodies
+  --cppBindStatic        bind cpp methods to their types
   --concat               concat the list of files into a single .nim file
   --concat:all           concat the list of files including c2nim files
   --debug                prints a c2nim stack trace in case of an error

--- a/c2nim.nimble
+++ b/c2nim.nimble
@@ -1,4 +1,4 @@
-version       = "0.9.19"
+version       = "0.10.0"
 author        = "Andreas Rumpf"
 description   = "c2nim is a tool to translate Ansi C code to Nim."
 license       = "MIT"

--- a/c2nim.nimble
+++ b/c2nim.nimble
@@ -1,4 +1,4 @@
-version       = "0.10.0"
+version       = "0.9.20"
 author        = "Andreas Rumpf"
 description   = "c2nim is a tool to translate Ansi C code to Nim."
 license       = "MIT"

--- a/cparser.nim
+++ b/cparser.nim
@@ -51,6 +51,7 @@ type
     pfReorderComments   ## reorder comments to match Nim's style
     pfFileNameIsPP      ## fixup pre-processor file name
     pfMergeBlocks       ## fixup pre-processor file name
+    pfCppBindStatic     ## bind cpp static methods to types
 
   Macro* = object
     name*: string
@@ -197,6 +198,7 @@ proc setOption*(parserOptions: PParserOptions, key: string, val=""): bool =
   of "structstruct": incl(parserOptions.flags, pfStructStruct)
   of "reordercomments": incl(parserOptions.flags, pfReorderComments)
   of "mergeblocks": incl(parserOptions.flags, pfMergeBlocks)
+  of "cppbindstatic": incl(parserOptions.flags, pfCppBindStatic)
   of "isarray": parserOptions.isArray[val] = "true"
   of "delete": parserOptions.deletes[val] = ""
   else: result = false
@@ -3101,7 +3103,7 @@ proc parseMethod(p: var Parser, origName: string, rettyp, pragmas: PNode,
     # declare 'this':
     thisDef = createThis(p, genericParamsThis)
     params.add(thisDef)
-  elif not isNil(p.currentClass):
+  elif not isNil(p.currentClass) and pfCppBindStatic in p.options.flags:
     # bind to type
     var typ = newNodeP(nkIdentDefs, p)
     var t = newNodeP(nkCommand, p)

--- a/cparser.nim
+++ b/cparser.nim
@@ -3101,6 +3101,14 @@ proc parseMethod(p: var Parser, origName: string, rettyp, pragmas: PNode,
     # declare 'this':
     thisDef = createThis(p, genericParamsThis)
     params.add(thisDef)
+  elif not isNil(p.currentClass):
+    # bind to type
+    var typ = newNodeP(nkIdentDefs, p)
+    var t = newNodeP(nkCommand, p)
+    t.add(newIdentNodeP("type", p))
+    t.add(p.currentClass.applyGenericParams(genericParamsThis))
+    addSon(typ, newIdentNodeP("_", p), t, emptyNode)
+    params.add(typ)
 
   parseFormalParams(p, params, pragmas)
   if p.tok.xkind == pxSymbol and p.tok.s == "const":

--- a/doc/c2nim.rst
+++ b/doc/c2nim.rst
@@ -577,6 +577,33 @@ not nested since the ``|}`` doesn't have to be on a line of its own:
 
   #define foobar {| 5 or 9 |}
 
+C++ static method binding
+=========================
+
+With ``--cppBindStatic``, C++ static methods will be bound to their types
+when possible:
+
+.. code-block:: C++
+
+   class ClassA
+   {
+     public:
+       static void hello();
+   };
+
+Produces for ``hello``:
+
+.. code-block:: Nim
+
+   proc hello*(_: type ClassA)
+
+   # which can be called like in CPP:
+   ClassA.hello()
+
+   # For static methods outside of classes, or when
+   # --cppBindStatic is not present:
+   proc hello*()
+   hello()
 
 
 Limitations

--- a/testsuite/results/cppstatic.nim
+++ b/testsuite/results/cppstatic.nim
@@ -1,0 +1,20 @@
+type
+  ClassA* {.importcpp: "ClassA", header: "cppstatic.hpp", bycopy.} = object
+
+
+proc test*(_: `type` ClassA) {.importcpp: "ClassA::test(@)",
+                               header: "cppstatic.hpp".}
+type
+  ClassB* {.importcpp: "ClassB", header: "cppstatic.hpp", bycopy.} = object
+
+
+proc test*(_: `type` ClassB) {.importcpp: "ClassB::test(@)",
+                               header: "cppstatic.hpp".}
+type
+  ClassGeneric*[T] {.importcpp: "ClassGeneric<\'0>", header: "cppstatic.hpp",
+                     bycopy.} = object
+
+
+proc test*[T](_: `type` ClassGeneric[T]) {.importcpp: "ClassGeneric::test(@)",
+    header: "cppstatic.hpp".}
+proc test*() {.importcpp: "test(@)", header: "cppstatic.hpp".}

--- a/testsuite/tester.nim
+++ b/testsuite/tester.nim
@@ -8,7 +8,7 @@ const
   c2nimCmd = dotslash & "c2nim $#"
   cpp2nimCmd = dotslash & "c2nim --cpp $#"
   cpp2nimCmdKeepBodies = dotslash & "c2nim --cpp --keepBodies $#"
-  hpp2nimCmd = dotslash & "c2nim --cpp --header $#"
+  hpp2nimCmd = dotslash & "c2nim --cpp --header --cppbindstatic $#"
   c2nimExtrasCmd = dotslash & "c2nim --stdints --strict --header --reordercomments --mergeblocks --render:reindentlongcomments --def:RCL_PUBLIC='__attribute__ (())' --def:RCL_WARN_UNUSED='__attribute__ (())' --def:'RCL_ALIGNAS(N)=__attribute__((align))' --render:extranewlines $#"
   dir = "testsuite/"
   usage = """

--- a/testsuite/tests/cppstatic.hpp
+++ b/testsuite/tests/cppstatic.hpp
@@ -1,0 +1,20 @@
+class ClassA
+{
+  public:
+    static void test();
+};
+
+class ClassB
+{
+  public:
+    static void test();
+};
+
+template <typename T>
+class ClassGeneric
+{
+  public:
+    static void test();
+};
+
+static void test();


### PR DESCRIPTION
```cpp
class ClassA
{
  public:
    static void test();
};
```

Now becomes
```nim
proc test*(_: `type` ClassA) {.importcpp: "ClassA::test(@)",
                               header: "cppstatic.hpp".}
```

(notice the added `type ClassA` parameter)
which can be used by doing ClassA.test()