### PR TITLE
Add clib pragma for configurable dynlib vs header 

### DIFF
--- a/cparser.nim
+++ b/cparser.nim
@@ -59,6 +59,7 @@ type
     pfCppSkipConverter  ## skip C++ converters
     pfCppSkipCallOp     ## skip C++ converters
     pfCppBindStatic     ## bind cpp static methods to types
+    pfClibUserPragma    ## user `clib` pragma instead of dynlib or header
 
   Macro* = object
     name*: string
@@ -72,7 +73,7 @@ type
     assumeDef, assumenDef: seq[string]
     mangleRules: seq[tuple[pattern: Peg, frmt: string]]
     privateRules: seq[Peg]
-    dynlibSym, headerOverride, headerPrefix: string
+    dynlibSym*, headerOverride, headerPrefix: string
     macros*: seq[Macro]
     deletes*: Table[string, string]
     toMangle: StringTableRef
@@ -162,6 +163,7 @@ proc setOption*(parserOptions: PParserOptions, key: string, val=""): bool =
   of "strict": incl(parserOptions.flags, pfStrict)
   of "ref": incl(parserOptions.flags, pfRefs)
   of "dynlib": parserOptions.dynlibSym = val
+  of "clibuserpragma": incl(parserOptions.flags, pfClibUserPragma)
   of "header":
     parserOptions.useHeader = true
     if val.len > 0: parserOptions.headerOverride = val

--- a/cparser.nim
+++ b/cparser.nim
@@ -75,7 +75,7 @@ type
     assumeDef, assumenDef: seq[string]
     mangleRules: seq[tuple[pattern: Peg, frmt: string]]
     privateRules: seq[Peg]
-    dynlibSym*, headerOverride, headerPrefix: string
+    dynlibSym, headerOverride, headerPrefix: string
     macros*: seq[Macro]
     deletes*: Table[string, string]
     toMangle: StringTableRef

--- a/doc/c2nim.rst
+++ b/doc/c2nim.rst
@@ -196,6 +196,23 @@ A binding that uses ``dynlib`` is much more preferable over one that uses
 ``header``! The Nim compiler might drop support for the ``header`` pragma
 in the future as it cannot work for backends that do not generate C code.
 
+``#clibuserpragma`` directive
+---------------------
+**Note**: There is also a ``--clibuserpragma`` command line option that can be used for
+the same purpose.
+
+This directive enables using a `clib` user definable pragma instead of a dynlib or 
+header pragmas. This can be used with a user defined pragma to provide a way to
+configure using a dynlib or a header import:
+
+.. code-block:: Nim
+
+  const rcutilsDynlib {.strdefine.}: string = ""
+  when rcutilsDynlib == "":
+    {.pragma: clib, header: "rcutils/cmdline_parser.h" .}
+  else:
+    {.pragma: clib, dynlib: "" & rcutilsDynlib.}
+
 
 ``#prefix`` and ``#suffix`` directives
 --------------------------------------

--- a/mangler.nim
+++ b/mangler.nim
@@ -104,7 +104,9 @@ proc addImportToPragma(pragmas: PNode, ident: string, p: Parser) =
     discard # already added importc pragma
   else:
     addSon(pragmas, newIdentStrLitPair(p.options.importcLit, p.currentNamespace & ident, p))
-  if p.options.dynlibSym.len > 0:
+  if pfClibUserPragma in p.options.flags:
+    addSon(pragmas, newIdentNodeP("clib", p))
+  elif p.options.dynlibSym.len > 0:
     addSon(pragmas, newIdentPair("dynlib", p.options.dynlibSym, p))
   else:
     addSon(pragmas, getHeaderPair(p))

--- a/preprocessor.nim
+++ b/preprocessor.nim
@@ -629,7 +629,8 @@ proc parseDir(p: var Parser; sectionParser: SectionParser, recur = false): PNode
      "keepbodies", "cpp", "cppallops", "nep1", "assumeifistrue", "structstruct",
      "importfuncdefines", "importdefines", "skipfuncdefines", "strict", "importc",
      "stdints", "reordercomments", "reordertypes", "mergeblocks", "mergeduplicates",
-     "cppspecialization", "cppskipconverter", "cppskipcallop":
+     "cppspecialization", "cppskipconverter", "cppskipcallop",
+     "clibuserpragma":
     discard setOption(p.options, p.tok.s)
     getTok(p)
     eatNewLine(p, nil)

--- a/testsuite/cextras/rcl_allocator_imp_pragma.h
+++ b/testsuite/cextras/rcl_allocator_imp_pragma.h
@@ -1,0 +1,23 @@
+
+//
+//The default allocator uses malloc(), free(), calloc(), and realloc().
+typedef struct rcutils_allocator_s
+{
+
+  /// allocate: Allocate memory, given a size and the `state` pointer.
+  void * (*allocate)(size_t size, void * state);
+
+  /** allocator objects.  */
+  void * state;
+
+
+} rcutils_allocator_t;
+
+
+/// Return a zero initialized allocator.
+/**
+ * Note that this is an invalid allocator and should only be used as a placeholder.
+ */
+rcutils_allocator_t rcutils_get_zero_initialized_allocator(void);
+
+

--- a/testsuite/cextras/rcl_allocator_imp_pragma.h
+++ b/testsuite/cextras/rcl_allocator_imp_pragma.h
@@ -1,3 +1,4 @@
+#pragma c2nim clibUserPragma
 
 //
 //The default allocator uses malloc(), free(), calloc(), and realloc().

--- a/testsuite/results/rcl_allocator_imp_pragma.nim
+++ b/testsuite/results/rcl_allocator_imp_pragma.nim
@@ -1,13 +1,7 @@
-
-const rosImportDynamic {.strdefine.}: string = ""
-when rosImportDynamic == "":
-  {.pragma: clib, header: "rcutils/time.h" .}
-else:
-  {.pragma: clib, dynlib: "" & importDynamic.}
-
 type
 
-  rcutils_allocator_t* {.importc: "rcutils_allocator_t", clib, bycopy.} = object ##
+  rcutils_allocator_t* {.importc: "rcutils_allocator_t",
+                         header: "rcl_allocator_imp_pragma.h", bycopy.} = object ##
                               ##
                               ## The default allocator uses malloc(), free(), calloc(), and realloc().
     allocate* {.importc: "allocate".}: proc (size: csize_t; state: pointer): pointer ##
@@ -18,7 +12,8 @@ type
 
 proc rcutils_get_zero_initialized_allocator*(): rcutils_allocator_t {.
     importc: "rcutils_get_zero_initialized_allocator", clib.}
-  ##  Return a zero initialized allocator.
-                                          ##
-                                          ##  Note that this is an invalid allocator and should only be used as a placeholder.
-                                          ## 
+  ##
+                              ##  Return a zero initialized allocator.
+                              ##
+                              ##  Note that this is an invalid allocator and should only be used as a placeholder.
+                              ## 

--- a/testsuite/results/rcl_allocator_imp_pragma.nim
+++ b/testsuite/results/rcl_allocator_imp_pragma.nim
@@ -1,0 +1,24 @@
+
+const rosImportDynamic {.strdefine.}: string = ""
+when rosImportDynamic == "":
+  {.pragma: clib, header: "rcutils/time.h" .}
+else:
+  {.pragma: clib, dynlib: "" & importDynamic.}
+
+type
+
+  rcutils_allocator_t* {.importc: "rcutils_allocator_t", clib, bycopy.} = object ##
+                              ##
+                              ## The default allocator uses malloc(), free(), calloc(), and realloc().
+    allocate* {.importc: "allocate".}: proc (size: csize_t; state: pointer): pointer ##
+                              ##  allocate: Allocate memory, given a size and the `state` pointer.
+    state* {.importc: "state".}: pointer ##  allocator objects.
+
+
+
+proc rcutils_get_zero_initialized_allocator*(): rcutils_allocator_t {.
+    importc: "rcutils_get_zero_initialized_allocator", clib.}
+  ##  Return a zero initialized allocator.
+                                          ##
+                                          ##  Note that this is an invalid allocator and should only be used as a placeholder.
+                                          ## 


### PR DESCRIPTION

``#clibuserpragma`` directive
---------------------
**Note**: There is also a ``--clibuserpragma`` command line option that can be used for
the same purpose.

This directive enables using a `clib` user definable pragma instead of a dynlib or 
header pragmas. This can be used with a user defined pragma to provide a way to
configure using a dynlib or a header import:

```nim
  const rcutilsDynlib {.strdefine.}: string = ""
  when rcutilsDynlib == "":
    {.pragma: clib, header: "rcutils/cmdline_parser.h" .}
  else:
    {.pragma: clib, dynlib: "" & rcutilsDynlib.}

proc rcutils_get_zero_initialized_allocator*(): rcutils_allocator_t {.
    importc: "rcutils_get_zero_initialized_allocator", clib.}
```
